### PR TITLE
Remove the "discard object on error" pattern

### DIFF
--- a/Lib/CSharp/nohtyP.cs
+++ b/Lib/CSharp/nohtyP.cs
@@ -750,7 +750,8 @@ namespace nohtyP
         internal static extern void yp_delindexC( ref ypObject_p sequence, yp_ssize_t i );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern void yp_delsliceC5( ref ypObject_p sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k );
+        internal static extern void yp_delsliceC5( ref ypObject_p sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k,
+                ref ypObject_p exc );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_delitem( ref ypObject_p sequence, ypObject_p key );
@@ -780,7 +781,8 @@ namespace nohtyP
         internal static extern void yp_reverse( ref ypObject_p sequence );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern void yp_sort4( ref ypObject_p sequence, yp_sort_key_func_t key, ypObject_p reverse );
+        internal static extern void yp_sort4( ref ypObject_p sequence, yp_sort_key_func_t key, ypObject_p reverse,
+                ref ypObject_p exc );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_sort( ref ypObject_p sequence );
@@ -920,7 +922,8 @@ namespace nohtyP
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_ipow( ref ypObject_p x, ypObject_p y );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern void yp_ipow4( ref ypObject_p x, ypObject_p y, ypObject_p z );
+        internal static extern void yp_ipow4( ref ypObject_p x, ypObject_p y, ypObject_p z,
+                ref ypObject_p exc );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_ineg( ref ypObject_p x );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]

--- a/Lib/CSharp/nohtyP.cs
+++ b/Lib/CSharp/nohtyP.cs
@@ -706,31 +706,31 @@ namespace nohtyP
         internal static extern ypObject_p yp_getitem( ypObject_p sequence, ypObject_p key );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern yp_ssize_t yp_findC4( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
+        internal static extern yp_ssize_t yp_findC5( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
                 ref ypObject_p exc );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern yp_ssize_t yp_findC( ypObject_p sequence, ypObject_p x, ref ypObject_p exc );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern yp_ssize_t yp_indexC4( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
+        internal static extern yp_ssize_t yp_indexC5( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
                 ref ypObject_p exc );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern yp_ssize_t yp_indexC( ypObject_p sequence, ypObject_p x, ref ypObject_p exc );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern yp_ssize_t yp_rfindC4( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
+        internal static extern yp_ssize_t yp_rfindC5( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
                 ref ypObject_p exc );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern yp_ssize_t yp_rfindC( ypObject_p sequence, ypObject_p x, ref ypObject_p exc );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern yp_ssize_t yp_rindexC4( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
+        internal static extern yp_ssize_t yp_rindexC5( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
                 ref ypObject_p exc );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern yp_ssize_t yp_rindexC( ypObject_p sequence, ypObject_p x, ref ypObject_p exc );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern yp_ssize_t yp_countC4( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
+        internal static extern yp_ssize_t yp_countC5( ypObject_p sequence, ypObject_p x, yp_ssize_t i, yp_ssize_t j,
                 ref ypObject_p exc );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
@@ -825,7 +825,7 @@ namespace nohtyP
         internal static extern void yp_set_add( ref ypObject_p set, ypObject_p x );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern void yp_pushuniqueE( ypObject_p set, ypObject_p x, ref ypObject_p exc );
+        internal static extern void yp_pushunique( ypObject_p set, ypObject_p x, ref ypObject_p exc );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern ypObject_p yp_getdefault( ypObject_p mapping, ypObject_p key, ypObject_p defval );

--- a/Lib/CSharp/nohtyP.cs
+++ b/Lib/CSharp/nohtyP.cs
@@ -920,7 +920,7 @@ namespace nohtyP
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_ipow( ref ypObject_p x, ypObject_p y );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern void yp_ipow3( ref ypObject_p x, ypObject_p y, ypObject_p z );
+        internal static extern void yp_ipow4( ref ypObject_p x, ypObject_p y, ypObject_p z );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_ineg( ref ypObject_p x );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
@@ -948,7 +948,7 @@ namespace nohtyP
         internal static extern void yp_ifloordivC( ypObject_p *x, yp_int_t y );
         internal static extern void yp_imodC( ypObject_p *x, yp_int_t y );
         internal static extern void yp_ipowC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_ipowC3( ypObject_p *x, yp_int_t y, yp_int_t z );
+        internal static extern void yp_ipowC4( ypObject_p *x, yp_int_t y, yp_int_t z );
         internal static extern void yp_ilshiftC( ypObject_p *x, yp_int_t y );
         internal static extern void yp_irshiftC( ypObject_p *x, yp_int_t y );
         internal static extern void yp_iampC( ypObject_p *x, yp_int_t y );
@@ -971,7 +971,7 @@ namespace nohtyP
         internal static extern yp_int_t yp_modL( yp_int_t x, yp_int_t y, ypObject_p *exc );
         internal static extern void yp_divmodL( yp_int_t x, yp_int_t y, yp_int_t *div, yp_int_t *mod, ypObject_p *exc );
         internal static extern yp_int_t yp_powL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_powL3( yp_int_t x, yp_int_t y, yp_int_t z, ypObject_p *exc );
+        internal static extern yp_int_t yp_powL4( yp_int_t x, yp_int_t y, yp_int_t z, ypObject_p *exc );
         internal static extern yp_int_t yp_negL( yp_int_t x, ypObject_p *exc );
         internal static extern yp_int_t yp_posL( yp_int_t x, ypObject_p *exc );
         internal static extern yp_int_t yp_absL( yp_int_t x, ypObject_p *exc );

--- a/Lib/CSharp/nohtyP.cs
+++ b/Lib/CSharp/nohtyP.cs
@@ -740,7 +740,7 @@ namespace nohtyP
         internal static extern void yp_setindexC( ref ypObject_p sequence, yp_ssize_t i, ypObject_p x );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern void yp_setsliceC5( ref ypObject_p sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k,
+        internal static extern void yp_setsliceC6( ref ypObject_p sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k,
                 ypObject_p x );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
@@ -750,7 +750,7 @@ namespace nohtyP
         internal static extern void yp_delindexC( ref ypObject_p sequence, yp_ssize_t i );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern void yp_delsliceC4( ref ypObject_p sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k );
+        internal static extern void yp_delsliceC5( ref ypObject_p sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_delitem( ref ypObject_p sequence, ypObject_p key );
@@ -780,7 +780,7 @@ namespace nohtyP
         internal static extern void yp_reverse( ref ypObject_p sequence );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
-        internal static extern void yp_sort3( ref ypObject_p sequence, yp_sort_key_func_t key, ypObject_p reverse );
+        internal static extern void yp_sort4( ref ypObject_p sequence, yp_sort_key_func_t key, ypObject_p reverse );
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_sort( ref ypObject_p sequence );
@@ -939,79 +939,6 @@ namespace nohtyP
         internal static extern void yp_ibar( ref ypObject_p x, ypObject_p y );
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern void yp_iinvert( ref ypObject_p x );
-
-#if NOTDEFINED
-        internal static extern void yp_iaddC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_isubC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_imulC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_itruedivC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_ifloordivC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_imodC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_ipowC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_ipowC4( ypObject_p *x, yp_int_t y, yp_int_t z );
-        internal static extern void yp_ilshiftC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_irshiftC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_iampC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_ixorC( ypObject_p *x, yp_int_t y );
-        internal static extern void yp_ibarC( ypObject_p *x, yp_int_t y );
-
-        internal static extern void yp_iaddCF( ypObject_p *x, yp_float_t y );
-        internal static extern void yp_isubCF( ypObject_p *x, yp_float_t y );
-        internal static extern void yp_imulCF( ypObject_p *x, yp_float_t y );
-        internal static extern void yp_itruedivCF( ypObject_p *x, yp_float_t y );
-        internal static extern void yp_ifloordivCF( ypObject_p *x, yp_float_t y );
-        internal static extern void yp_imodCF( ypObject_p *x, yp_float_t y );
-        internal static extern void yp_ipowCF( ypObject_p *x, yp_float_t y );
-
-        internal static extern yp_int_t yp_addL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_subL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_mulL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_float_t yp_truedivL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_floordivL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_modL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern void yp_divmodL( yp_int_t x, yp_int_t y, yp_int_t *div, yp_int_t *mod, ypObject_p *exc );
-        internal static extern yp_int_t yp_powL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_powL4( yp_int_t x, yp_int_t y, yp_int_t z, ypObject_p *exc );
-        internal static extern yp_int_t yp_negL( yp_int_t x, ypObject_p *exc );
-        internal static extern yp_int_t yp_posL( yp_int_t x, ypObject_p *exc );
-        internal static extern yp_int_t yp_absL( yp_int_t x, ypObject_p *exc );
-        internal static extern yp_int_t yp_lshiftL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_rshiftL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_ampL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_xorL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_barL( yp_int_t x, yp_int_t y, ypObject_p *exc );
-        internal static extern yp_int_t yp_invertL( yp_int_t x, ypObject_p *exc );
-
-        internal static extern yp_float_t yp_addLF( yp_float_t x, yp_float_t y, ypObject_p *exc );
-        internal static extern yp_float_t yp_subLF( yp_float_t x, yp_float_t y, ypObject_p *exc );
-        internal static extern yp_float_t yp_mulLF( yp_float_t x, yp_float_t y, ypObject_p *exc );
-        internal static extern yp_float_t yp_truedivLF( yp_float_t x, yp_float_t y, ypObject_p *exc );
-        internal static extern yp_float_t yp_floordivLF( yp_float_t x, yp_float_t y, ypObject_p *exc );
-        internal static extern yp_float_t yp_modLF( yp_float_t x, yp_float_t y, ypObject_p *exc );
-        internal static extern void yp_divmodLF( yp_float_t x, yp_float_t y,
-                yp_float_t *div, yp_float_t *mod, ypObject_p *exc );
-        internal static extern yp_float_t yp_powLF( yp_float_t x, yp_float_t y, ypObject_p *exc );
-        internal static extern yp_float_t yp_negLF( yp_float_t x, ypObject_p *exc );
-        internal static extern yp_float_t yp_posLF( yp_float_t x, ypObject_p *exc );
-        internal static extern yp_float_t yp_absLF( yp_float_t x, ypObject_p *exc );
-
-        internal static extern yp_int_t yp_asintC( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_int8_t yp_asint8C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_uint8_t yp_asuint8C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_int16_t yp_asint16C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_uint16_t yp_asuint16C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_int32_t yp_asint32C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_uint32_t yp_asuint32C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_int64_t yp_asint64C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_uint64_t yp_asuint64C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_float_t yp_asfloatC( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_float32_t yp_asfloat32C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_float64_t yp_asfloat64C( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_ssize_t yp_asssizeC( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_hash_t yp_ashashC( ypObject_p x, ypObject_p *exc );
-        internal static extern yp_float_t yp_asfloatL( yp_int_t x, ypObject_p *exc );
-        internal static extern yp_int_t yp_asintLF( yp_float_t x, ypObject_p *exc );
-#endif
 
         [DllImport( DLL_NAME, CallingConvention = CALLCONV )]
         internal static extern ypObject_p yp_roundC( ypObject_p x, int ndigits );

--- a/Lib/yp.py
+++ b/Lib/yp.py
@@ -390,8 +390,7 @@ yp_func(c_void, "yp_push", ((c_ypObject_p, "container"), (c_ypObject_p, "x"), c_
 yp_func(c_void, "yp_clear", ((c_ypObject_p, "container"), c_ypObject_pp_exc))
 
 # ypObject *yp_pop(ypObject *container);
-yp_func(c_ypObject_p, "yp_pop", ((c_ypObject_p, "container")))
-
+yp_func(c_ypObject_p, "yp_pop", ((c_ypObject_p, "container"), ))
 
 # ypObject *yp_concat(ypObject *sequence, ypObject *x);
 yp_func(c_ypObject_p, "yp_concat", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x")))
@@ -406,49 +405,49 @@ yp_func(c_ypObject_p, "yp_getindexC", ((c_ypObject_p, "sequence"), (c_yp_ssize_t
 yp_func(c_ypObject_p, "yp_getsliceC4", ((c_ypObject_p, "sequence"),
                                         (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), (c_yp_ssize_t, "k")))
 
-# yp_ssize_t yp_findC4(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
+# yp_ssize_t yp_findC5(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
 #         ypObject **exc);
-yp_func(c_yp_ssize_t, "yp_findC4", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
+yp_func(c_yp_ssize_t, "yp_findC5", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                     (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), c_ypObject_pp_exc))
 
 # yp_ssize_t yp_findC(ypObject *sequence, ypObject *x, ypObject **exc);
 yp_func(c_yp_ssize_t, "yp_findC", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                    c_ypObject_pp_exc))
 
-# yp_ssize_t yp_indexC4(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
+# yp_ssize_t yp_indexC5(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
 #         ypObject **exc);
-yp_func(c_yp_ssize_t, "yp_indexC4", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
+yp_func(c_yp_ssize_t, "yp_indexC5", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                      (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), c_ypObject_pp_exc))
 # yp_ssize_t yp_indexC(ypObject *sequence, ypObject *x, ypObject **exc);
 yp_func(c_yp_ssize_t, "yp_indexC", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                     c_ypObject_pp_exc))
 
-# yp_ssize_t yp_rfindC4(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
+# yp_ssize_t yp_rfindC5(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
 #         ypObject **exc);
-yp_func(c_yp_ssize_t, "yp_rfindC4", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
+yp_func(c_yp_ssize_t, "yp_rfindC5", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                      (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), c_ypObject_pp_exc))
 # yp_ssize_t yp_rfindC(ypObject *sequence, ypObject *x, ypObject **exc);
 yp_func(c_yp_ssize_t, "yp_rfindC", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                     c_ypObject_pp_exc))
-# yp_ssize_t yp_rindexC4(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
+# yp_ssize_t yp_rindexC5(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
 #         ypObject **exc);
-yp_func(c_yp_ssize_t, "yp_rindexC4", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
+yp_func(c_yp_ssize_t, "yp_rindexC5", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                       (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), c_ypObject_pp_exc))
 # yp_ssize_t yp_rindexC(ypObject *sequence, ypObject *x, ypObject **exc);
 yp_func(c_yp_ssize_t, "yp_rindexC", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                      c_ypObject_pp_exc))
 
-# yp_ssize_t yp_countC4(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
+# yp_ssize_t yp_countC5(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
 #        ypObject **exc);
-yp_func(c_yp_ssize_t, "yp_countC4", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
+yp_func(c_yp_ssize_t, "yp_countC5", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                      (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), c_ypObject_pp_exc))
 
 # yp_ssize_t yp_countC(ypObject *sequence, ypObject *x, ypObject **exc);
 yp_func(c_yp_ssize_t, "yp_countC", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                     c_ypObject_pp_exc))
 
-# void yp_setsliceC6(
-#         ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject *x, ypObject **exc);
+# void yp_setsliceC6(ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject *x,
+#         ypObject **exc);
 yp_func(c_void, "yp_setsliceC6", ((c_ypObject_p, "sequence"),
                                   (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), (c_yp_ssize_t, "k"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
@@ -527,7 +526,7 @@ yp_func(c_void, "yp_symmetric_difference_update", ((c_ypObject_p, "set"), (c_ypO
 yp_func(c_void, "yp_set_add", ((c_ypObject_p, "set"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
 # void yp_pushunique(ypObject *set, ypObject *x, ypObject **exc);
-yp_func(c_void, "yp_pushuniqueE", ((c_ypObject_p, "set"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
+yp_func(c_void, "yp_pushunique", ((c_ypObject_p, "set"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
 # void yp_discard(ypObject *set, ypObject *x, ypObject **exc);
 yp_func(c_void, "yp_discard", ((c_ypObject_p, "set"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
@@ -970,9 +969,9 @@ class ypObject(c_ypObject_p):
         exc._yp_errcheck()
         return result
 
-    def push(self, x): _yp_push(self, x)
+    def push(self, x): _yp_push(self, x, yp_None)
 
-    def clear(self): _yp_clear(self)
+    def clear(self): _yp_clear(self, yp_None)
 
     def pop(self): return _yp_pop(self)
 
@@ -986,30 +985,30 @@ class ypObject(c_ypObject_p):
         return func4(self, x, i, j, *extra)
 
     def find(self, x, i=None, j=None):
-        return yp_int(self._sliceSearch(_yp_findC, _yp_findC4, x, i, j, yp_None))
+        return yp_int(self._sliceSearch(_yp_findC, _yp_findC5, x, i, j, yp_None))
 
     def index(self, x, i=None, j=None):
-        return yp_int(self._sliceSearch(_yp_indexC, _yp_indexC4, x, i, j, yp_None))
+        return yp_int(self._sliceSearch(_yp_indexC, _yp_indexC5, x, i, j, yp_None))
 
     def rfind(self, x, i=None, j=None):
-        return yp_int(self._sliceSearch(_yp_rfindC, _yp_rfindC4, x, i, j, yp_None))
+        return yp_int(self._sliceSearch(_yp_rfindC, _yp_rfindC5, x, i, j, yp_None))
 
     def rindex(self, x, i=None, j=None):
-        return yp_int(self._sliceSearch(_yp_rindexC, _yp_rindexC4, x, i, j, yp_None))
+        return yp_int(self._sliceSearch(_yp_rindexC, _yp_rindexC5, x, i, j, yp_None))
 
     def count(self, x, i=None, j=None):
-        return yp_int(self._sliceSearch(_yp_countC, _yp_countC4, x, i, j, yp_None))
+        return yp_int(self._sliceSearch(_yp_countC, _yp_countC5, x, i, j, yp_None))
 
-    def append(self, x): _yp_append(self, x)
+    def append(self, x): _yp_append(self, x, yp_None)
 
-    def extend(self, t): _yp_extend(self, _yp_iterable(t))
+    def extend(self, t): _yp_extend(self, _yp_iterable(t), yp_None)
 
-    def insert(self, i, x): _yp_insertC(self, i, x)
+    def insert(self, i, x): _yp_insertC(self, i, x, yp_None)
 
-    def reverse(self): _yp_reverse(self)
+    def reverse(self): _yp_reverse(self, yp_None)
 
     def sort(self, *, key=None, reverse=False):
-        _yp_sort3(self, key, reverse)
+        _yp_sort4(self, key, reverse, yp_None)
 
     def isdisjoint(self, other):
         return _yp_isdisjoint(self, _yp_iterable(other))
@@ -1033,20 +1032,20 @@ class ypObject(c_ypObject_p):
         return _yp_symmetric_difference(self, _yp_iterable(other))
 
     def update(self, *others):
-        _yp_updateN(self, *(_yp_iterable(x) for x in others))
+        _yp_updateN(self, yp_None, *(_yp_iterable(x) for x in others))
 
     def intersection_update(self, *others):
-        _yp_intersection_updateN(self, *(_yp_iterable(x) for x in others))
+        _yp_intersection_updateN(self, yp_None, *(_yp_iterable(x) for x in others))
 
     def difference_update(self, *others):
-        _yp_difference_updateN(self, *(_yp_iterable(x) for x in others))
+        _yp_difference_updateN(self, yp_None, *(_yp_iterable(x) for x in others))
 
     def symmetric_difference_update(self, other):
-        _yp_symmetric_difference_update(self, _yp_iterable(other))
+        _yp_symmetric_difference_update(self, _yp_iterable(other), yp_None)
 
-    def remove(self, elem): _yp_remove(self, elem)
+    def remove(self, elem): _yp_remove(self, elem, yp_None)
 
-    def discard(self, elem): _yp_discard(self, elem)
+    def discard(self, elem): _yp_discard(self, elem, yp_None)
 
     def _slice(self, func, key, *args):
         start, stop, step = key.start, key.stop, key.step
@@ -1066,15 +1065,15 @@ class ypObject(c_ypObject_p):
 
     def __setitem__(self, key, value):
         if isinstance(key, slice):
-            self._slice(_yp_setsliceC5, key, value)
+            self._slice(_yp_setsliceC6, key, value, yp_None)
         else:
-            _yp_setitem(self, key, value)
+            _yp_setitem(self, key, value, yp_None)
 
     def __delitem__(self, key):
         if isinstance(key, slice):
-            self._slice(_yp_delsliceC4, key)
+            self._slice(_yp_delsliceC5, key, yp_None)
         else:
-            _yp_delitem(self, key)
+            _yp_delitem(self, key, yp_None)
 
     def get(self, key, defval=None): return _yp_getdefault(self, key, defval)
 
@@ -1648,13 +1647,13 @@ class yp_bytearray(_ypBytes):
             return _yp_popindexC(self, i)
 
     def __iadd__(self, other):
-        _yp_extend(self, other)
+        _yp_extend(self, other, yp_None)
         return self
 
     def __imul__(self, factor):
         if isinstance(factor, float):
             raise TypeError
-        _yp_irepeatC(self, factor)
+        _yp_irepeatC(self, factor, None)
         return self
     # XXX nohtyP will return a chrarray if asked to decode a bytearray, but Python expects str
 
@@ -1823,13 +1822,13 @@ class yp_list(_ypTuple):
             return _yp_popindexC(self, i)
 
     def __iadd__(self, other):
-        _yp_extend(self, other)
+        _yp_extend(self, other, yp_None)
         return self
 
     def __imul__(self, factor):
         if isinstance(factor, float):
             raise TypeError
-        _yp_irepeatC(self, factor)
+        _yp_irepeatC(self, factor, yp_None)
         return self
 
 
@@ -1885,28 +1884,28 @@ class _ypSet(ypObject):
     def __ior__(self, other):
         if self._bad_other(other):
             return NotImplemented
-        _yp_updateN(self, other)
+        _yp_updateN(self, yp_None, other)
         return self
 
     def __iand__(self, other):
         if self._bad_other(other):
             return NotImplemented
-        _yp_intersection_updateN(self, other)
+        _yp_intersection_updateN(self, yp_None, other)
         return self
 
     def __isub__(self, other):
         if self._bad_other(other):
             return NotImplemented
-        _yp_difference_updateN(self, other)
+        _yp_difference_updateN(self, yp_None, other)
         return self
 
     def __ixor__(self, other):
         if self._bad_other(other):
             return NotImplemented
-        _yp_symmetric_difference_update(self, other)
+        _yp_symmetric_difference_update(self, other, yp_None)
         return self
 
-    def add(self, elem): _yp_set_add(self, elem)
+    def add(self, elem): _yp_set_add(self, elem, yp_None)
 
 
 @pytype(yp_t_frozenset, frozenset)
@@ -2068,7 +2067,7 @@ class _ypDict(ypObject):
         return (key_p[0], value_p[0])
 
     def update(self, object=yp_tuple_empty, /, **kwargs):
-        _yp_updateN(self, _yp_dict_iterable(object), kwargs)
+        _yp_updateN(self, yp_None, _yp_dict_iterable(object), kwargs)
 
 
 @pytype(yp_t_frozendict, ())

--- a/Lib/yp.py
+++ b/Lib/yp.py
@@ -963,7 +963,7 @@ yp_func(c_ypObject_p, "yp_invert", ((c_ypObject_p, "x"), ))
 # void yp_ifloordiv(ypObject **x, ypObject *y);
 # void yp_imod(ypObject **x, ypObject *y);
 # void yp_ipow(ypObject **x, ypObject *y);
-# void yp_ipow3(ypObject **x, ypObject *y, ypObject *z);
+# void yp_ipow4(ypObject **x, ypObject *y, ypObject *z);
 # void yp_ilshift(ypObject **x, ypObject *y);
 # void yp_irshift(ypObject **x, ypObject *y);
 # void yp_iamp(ypObject **x, ypObject *y);
@@ -981,7 +981,7 @@ yp_func(c_ypObject_p, "yp_invert", ((c_ypObject_p, "x"), ))
 # void yp_ifloordivC(ypObject **x, yp_int_t y);
 # void yp_imodC(ypObject **x, yp_int_t y);
 # void yp_ipowC(ypObject **x, yp_int_t y);
-# void yp_ipowC3(ypObject **x, yp_int_t y, yp_int_t z);
+# void yp_ipowC4(ypObject **x, yp_int_t y, yp_int_t z);
 # void yp_ilshiftC(ypObject **x, yp_int_t y);
 # void yp_irshiftC(ypObject **x, yp_int_t y);
 # void yp_iampC(ypObject **x, yp_int_t y);
@@ -1009,7 +1009,7 @@ yp_func(c_ypObject_p, "yp_invert", ((c_ypObject_p, "x"), ))
 # yp_int_t yp_modL(yp_int_t x, yp_int_t y, ypObject **exc);
 # void yp_divmodL(yp_int_t x, yp_int_t y, yp_int_t *div, yp_int_t *mod, ypObject **exc);
 # yp_int_t yp_powL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_powL3(yp_int_t x, yp_int_t y, yp_int_t z, ypObject **exc);
+# yp_int_t yp_powL4(yp_int_t x, yp_int_t y, yp_int_t z, ypObject **exc);
 # yp_int_t yp_lshiftL(yp_int_t x, yp_int_t y, ypObject **exc);
 # yp_int_t yp_rshiftL(yp_int_t x, yp_int_t y, ypObject **exc);
 # yp_int_t yp_ampL(yp_int_t x, yp_int_t y, ypObject **exc);

--- a/Lib/yp.py
+++ b/Lib/yp.py
@@ -193,42 +193,20 @@ class c_ypObject_pp(c_ypObject_p*1):
 
     def __reduce__(self): raise pickle.PicklingError("can't pickle nohtyP types (yet)")
 
-# ypObject *yp_None;
-
 # Special-case arguments
 c_ypObject_pp_exc = (c_ypObject_pp, "exc", None)
 c_multiN_ypObject_p = (c_int, "n", 0)
 c_multiK_ypObject_p = (c_int, "n", 0)
 assert c_multiN_ypObject_p is not c_multiK_ypObject_p
 
-# void yp_initialize(yp_initialize_parameters_t *kwparams);
-
 # ypObject *yp_incref(ypObject *x);
 yp_func(c_void_p, "yp_incref", ((c_ypObject_p, "x"), ), errcheck=False)
-
-# void yp_increfN(int n, ...);
-# void yp_increfNV(int n, va_list args);
 
 # void yp_decref(ypObject *x);
 yp_func(c_void, "yp_decref", ((c_ypObject_p, "x"), ), errcheck=False)
 
-# void yp_decrefN(int n, ...);
-# void yp_decrefNV(int n, va_list args);
-
 # int yp_isexceptionC(ypObject *x);
 yp_func(c_int, "yp_isexceptionC", ((c_ypObject_p, "x"), ), errcheck=False)
-
-# void yp_freeze(ypObject **x);
-
-# void yp_deepfreeze(ypObject **x);
-
-# ypObject *yp_unfrozen_copy(ypObject *x);
-
-# ypObject *yp_unfrozen_deepcopy(ypObject *x);
-
-# ypObject *yp_frozen_copy(ypObject *x);
-
-# ypObject *yp_frozen_deepcopy(ypObject *x);
 
 # ypObject *yp_copy(ypObject *x);
 yp_func(c_ypObject_p, "yp_copy", ((c_ypObject_p, "x"), ))
@@ -236,39 +214,11 @@ yp_func(c_ypObject_p, "yp_copy", ((c_ypObject_p, "x"), ))
 # ypObject *yp_deepcopy(ypObject *x);
 yp_func(c_ypObject_p, "yp_deepcopy", ((c_ypObject_p, "x"), ))
 
-# void yp_invalidate(ypObject **x);
-
-# void yp_deepinvalidate(ypObject **x);
-
-
-# ypObject *yp_True;
-# ypObject *yp_False;
-
 # ypObject *yp_bool(ypObject *x);
 yp_func(c_ypObject_p, "yp_bool", ((c_ypObject_p, "x"), ))
 
 # ypObject *yp_not(ypObject *x);
 yp_func(c_ypObject_p, "yp_not", ((c_ypObject_p, "x"), ))
-
-# ypObject *yp_or(ypObject *x, ypObject *y);
-
-# ypObject *yp_orN(int n, ...);
-# ypObject *yp_orNV(int n, va_list args);
-
-# ypObject *yp_anyN(int n, ...);
-# ypObject *yp_anyNV(int n, va_list args);
-
-# ypObject *yp_any(ypObject *iterable);
-
-# ypObject *yp_and(ypObject *x, ypObject *y);
-
-# ypObject *yp_andN(int n, ...);
-# ypObject *yp_andNV(int n, va_list args);
-
-# ypObject *yp_allN(int n, ...);
-# ypObject *yp_allNV(int n, va_list args);
-
-# ypObject *yp_all(ypObject *iterable);
 
 # ypObject *yp_lt(ypObject *x, ypObject *y);
 # ypObject *yp_le(ypObject *x, ypObject *y);
@@ -282,7 +232,6 @@ yp_func(c_ypObject_p, "yp_eq", ((c_ypObject_p, "x"), (c_ypObject_p, "y")))
 yp_func(c_ypObject_p, "yp_ne", ((c_ypObject_p, "x"), (c_ypObject_p, "y")))
 yp_func(c_ypObject_p, "yp_ge", ((c_ypObject_p, "x"), (c_ypObject_p, "y")))
 yp_func(c_ypObject_p, "yp_gt", ((c_ypObject_p, "x"), (c_ypObject_p, "y")))
-
 
 # typedef float               yp_float32_t;
 c_yp_float32_t = c_float
@@ -347,23 +296,9 @@ class c_yp_function_decl_t(Structure):
 
 # ypObject *yp_intC(yp_int_t value);
 yp_func(c_ypObject_p, "yp_intC", ((c_yp_int_t, "value"), ))
-# ypObject *yp_intstoreC(yp_int_t value);
-
-# ypObject *yp_int_baseC(ypObject *x, yp_int_t base);
-# ypObject *yp_intstore_baseC(ypObject *x, yp_int_t base);
-
-# ypObject *yp_int(ypObject *x);
-# ypObject *yp_intstore(ypObject *x);
 
 # ypObject *yp_floatCF(yp_float_t value);
 yp_func(c_ypObject_p, "yp_floatCF", ((c_yp_float_t, "value"), ))
-# ypObject *yp_floatstoreCF(yp_float_t value);
-
-# ypObject *yp_float_strC(const char *string);
-# ypObject *yp_floatstore_strC(const char *string);
-
-# ypObject *yp_float(ypObject *x);
-# ypObject *yp_floatstore(ypObject *x);
 
 # ypObject *yp_iter(ypObject *x);
 yp_func(c_ypObject_p, "yp_iter", ((c_ypObject_p, "x"), ))
@@ -374,71 +309,38 @@ yp_func(c_ypObject_p, "yp_generatorC", ((POINTER(c_yp_generator_decl_t), "declar
 # ypObject *yp_rangeC3(yp_int_t start, yp_int_t stop, yp_int_t step);
 yp_func(c_ypObject_p, "yp_rangeC3",
         ((c_yp_int_t, "start"), (c_yp_int_t, "stop"), (c_yp_int_t, "step")))
-# ypObject *yp_rangeC(yp_int_t stop);
 
 # ypObject *yp_bytesC(const yp_uint8_t *source, yp_ssize_t len);
 yp_func(c_ypObject_p, "yp_bytesC", ((c_char_p, "source"), (c_yp_ssize_t, "len")))
 # ypObject *yp_bytearrayC(const yp_uint8_t *source, yp_ssize_t len);
 yp_func(c_ypObject_p, "yp_bytearrayC", ((c_char_p, "source"), (c_yp_ssize_t, "len")))
 
-# ypObject *yp_bytes3(ypObject *source, ypObject *encoding, ypObject *errors);
-# ypObject *yp_bytearray3(ypObject *source, ypObject *encoding, ypObject *errors);
-
-# ypObject *yp_bytes(ypObject *source);
-# ypObject *yp_bytearray(ypObject *source);
-
-# ypObject *yp_bytearray0(void);
-
 # ypObject *yp_str_frombytesC4(const yp_uint8_t *source, yp_ssize_t len,
 #         ypObject *encoding, ypObject *errors);
 yp_func(c_ypObject_p, "yp_str_frombytesC4", ((c_char_p, "source"), (c_yp_ssize_t, "len"),
                                              (c_ypObject_p, "encoding"), (c_ypObject_p, "errors")))
-# ypObject *yp_chrarray_frombytesC4(const yp_uint8_t *source, yp_ssize_t len,
-#         ypObject *encoding, ypObject *errors);
 
 # ypObject *yp_str_frombytesC2(const yp_uint8_t *source, yp_ssize_t len);
 yp_func(c_ypObject_p, "yp_str_frombytesC2", ((c_char_p, "source"), (c_yp_ssize_t, "len")))
-# ypObject *yp_chrarray_frombytesC2(const yp_uint8_t *source, yp_ssize_t len);
 
 # ypObject *yp_str3(ypObject *object, ypObject *encoding, ypObject *errors);
 yp_func(c_ypObject_p, "yp_str3", ((c_ypObject_p, "object"),
                                   (c_ypObject_p, "encoding"), (c_ypObject_p, "errors")))
-# ypObject *yp_chrarray3(ypObject *object, ypObject *encoding, ypObject *errors);
-
-# ypObject *yp_str(ypObject *object);
-# ypObject *yp_chrarray(ypObject *object);
-
-# ypObject *yp_chrarray0(void);
-
-# ypObject *yp_chrC(yp_int_t i);
 
 # ypObject *yp_tupleN(int n, ...);
-# ypObject *yp_tupleNV(int n, va_list args);
 yp_func(c_ypObject_p, "yp_tupleN", (c_multiN_ypObject_p, ))
 
 # ypObject *yp_listN(int n, ...);
-# ypObject *yp_listNV(int n, va_list args);
 yp_func(c_ypObject_p, "yp_listN", (c_multiN_ypObject_p, ))
-
-# ypObject *yp_tuple_repeatCN(yp_ssize_t factor, int n, ...);
-# ypObject *yp_tuple_repeatCNV(yp_ssize_t factor, int n, va_list args);
-# ypObject *yp_list_repeatCN(yp_ssize_t factor, int n, ...);
-# ypObject *yp_list_repeatCNV(yp_ssize_t factor, int n, va_list args);
 
 # ypObject *yp_tuple(ypObject *iterable);
 yp_func(c_ypObject_p, "yp_tuple", ((c_ypObject_p, "iterable"), ))
 # ypObject *yp_list(ypObject *iterable);
 yp_func(c_ypObject_p, "yp_list", ((c_ypObject_p, "iterable"), ))
 
-# ypObject *yp_sorted3(ypObject *iterable, ypObject *key, ypObject *reverse);
-
-# ypObject *yp_sorted(ypObject *iterable);
-
 # ypObject *yp_frozensetN(int n, ...);
-# ypObject *yp_frozensetNV(int n, va_list args);
 yp_func(c_ypObject_p, "yp_frozensetN", (c_multiN_ypObject_p, ))
 # ypObject *yp_setN(int n, ...);
-# ypObject *yp_setNV(int n, va_list args);
 yp_func(c_ypObject_p, "yp_setN", (c_multiN_ypObject_p, ))
 
 # ypObject *yp_frozenset(ypObject *iterable);
@@ -446,17 +348,12 @@ yp_func(c_ypObject_p, "yp_frozenset", ((c_ypObject_p, "iterable"), ))
 # ypObject *yp_set(ypObject *iterable);
 yp_func(c_ypObject_p, "yp_set", ((c_ypObject_p, "iterable"), ))
 
-# ypObject *yp_frozendictK(int n, ...);
-# ypObject *yp_frozendictKV(int n, va_list args);
 # ypObject *yp_dictK(int n, ...);
-# ypObject *yp_dictKV(int n, va_list args);
 yp_func(c_ypObject_p, "yp_dictK", (c_multiK_ypObject_p, ))
 
 # ypObject *yp_frozendict_fromkeysN(ypObject *value, int n, ...);
-# ypObject *yp_frozendict_fromkeysNV(ypObject *value, int n, va_list args);
 yp_func(c_ypObject_p, "yp_frozendict_fromkeysN", ((c_ypObject_p, "value"), c_multiN_ypObject_p))
 # ypObject *yp_dict_fromkeysN(ypObject *value, int n, ...);
-# ypObject *yp_dict_fromkeysNV(ypObject *value, int n, va_list args);
 yp_func(c_ypObject_p, "yp_dict_fromkeysN", ((c_ypObject_p, "value"), c_multiN_ypObject_p))
 
 # ypObject *yp_frozendict(ypObject *x);
@@ -467,77 +364,33 @@ yp_func(c_ypObject_p, "yp_dict", ((c_ypObject_p, "x"), ))
 # ypObject *yp_functionC(yp_function_decl_t *declaration);
 yp_func(c_ypObject_p, "yp_functionC", ((POINTER(c_yp_function_decl_t), "declaration"), ))
 
-# XXX The file type will be added in a future version
-
-
 # yp_hash_t yp_hashC(ypObject *x, ypObject **exc);
 yp_func(c_yp_hash_t, "yp_hashC", ((c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# yp_hash_t yp_currenthashC(ypObject *x, ypObject **exc);
-
-
-# ypObject *yp_send(ypObject *iterator, ypObject *value);
-
 # ypObject *yp_next(ypObject *iterator);
-yp_func(c_ypObject_p, "yp_next", ((c_ypObject_pp, "iterator"), ))
-
-# ypObject *yp_next2(ypObject *iterator, ypObject *defval);
-
-# ypObject *yp_throw(ypObject *iterator, ypObject *exc);
+yp_func(c_ypObject_p, "yp_next", ((c_ypObject_p, "iterator"), ))
 
 # yp_ssize_t yp_length_hintC(ypObject *iterator, ypObject **exc);
 yp_func(c_yp_ssize_t, "yp_length_hintC", ((c_ypObject_p, "iterator"), c_ypObject_pp_exc))
 
-# ypObject *yp_iter_stateCX(ypObject *iterator, void **state, yp_ssize_t *size);
-
-# void yp_close(ypObject **iterator);
-
-# typedef ypObject *(*yp_filter_function_t)(ypObject *x);
-# ypObject *yp_filter(yp_filter_function_t function, ypObject *iterable);
-
-# ypObject *yp_filterfalse(yp_filter_function_t function, ypObject *iterable);
-
-# ypObject *yp_max_keyN(ypObject *key, int n, ...);
-# ypObject *yp_max_keyNV(ypObject *key, int n, va_list args);
-# ypObject *yp_min_keyN(ypObject *key, int n, ...);
-# ypObject *yp_min_keyNV(ypObject *key, int n, va_list args);
-
-# ypObject *yp_maxN(int n, ...);
-# ypObject *yp_maxNV(int n, va_list args);
-# ypObject *yp_minN(int n, ...);
-# ypObject *yp_minNV(int n, va_list args);
-
-# ypObject *yp_max_key(ypObject *iterable, ypObject *key);
-# ypObject *yp_min_key(ypObject *iterable, ypObject *key);
-
-# ypObject *yp_max(ypObject *iterable);
-# ypObject *yp_min(ypObject *iterable);
-
 # ypObject *yp_reversed(ypObject *seq);
 yp_func(c_ypObject_p, "yp_reversed", ((c_ypObject_p, "seq"), ))
 
-# ypObject *yp_zipN(int n, ...);
-# ypObject *yp_zipNV(int n, va_list args);
-
-
 # ypObject *yp_contains(ypObject *container, ypObject *x);
 yp_func(c_ypObject_p, "yp_contains", ((c_ypObject_p, "container"), (c_ypObject_p, "x")))
-# ypObject *yp_in(ypObject *x, ypObject *container);
-
-# ypObject *yp_not_in(ypObject *x, ypObject *container);
 
 # yp_ssize_t yp_lenC(ypObject *container, ypObject **exc);
 yp_func(c_yp_ssize_t, "yp_lenC", ((c_ypObject_p, "container"), c_ypObject_pp_exc),
         errcheck=False)
 
-# void yp_push(ypObject **container, ypObject *x);
-yp_func(c_void, "yp_push", ((c_ypObject_pp, "container"), (c_ypObject_p, "x")))
+# void yp_push(ypObject *container, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_push", ((c_ypObject_p, "container"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# void yp_clear(ypObject **container);
-yp_func(c_void, "yp_clear", ((c_ypObject_pp, "container"), ))
+# void yp_clear(ypObject *container, ypObject **exc);
+yp_func(c_void, "yp_clear", ((c_ypObject_p, "container"), c_ypObject_pp_exc))
 
-# ypObject *yp_pop(ypObject **container);
-yp_func(c_ypObject_p, "yp_pop", ((c_ypObject_pp, "container"), ))
+# ypObject *yp_pop(ypObject *container);
+yp_func(c_ypObject_p, "yp_pop", ((c_ypObject_p, "container")))
 
 
 # ypObject *yp_concat(ypObject *sequence, ypObject *x);
@@ -552,8 +405,6 @@ yp_func(c_ypObject_p, "yp_getindexC", ((c_ypObject_p, "sequence"), (c_yp_ssize_t
 # ypObject *yp_getsliceC4(ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k);
 yp_func(c_ypObject_p, "yp_getsliceC4", ((c_ypObject_p, "sequence"),
                                         (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), (c_yp_ssize_t, "k")))
-
-# ypObject *yp_getitem(ypObject *sequence, ypObject *key);
 
 # yp_ssize_t yp_findC4(ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j,
 #         ypObject **exc);
@@ -596,54 +447,43 @@ yp_func(c_yp_ssize_t, "yp_countC4", ((c_ypObject_p, "sequence"), (c_ypObject_p, 
 yp_func(c_yp_ssize_t, "yp_countC", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"),
                                     c_ypObject_pp_exc))
 
-# void yp_setindexC(ypObject **sequence, yp_ssize_t i, ypObject *x);
+# void yp_setsliceC6(
+#         ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_setsliceC6", ((c_ypObject_p, "sequence"),
+                                  (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), (c_yp_ssize_t, "k"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# void yp_setsliceC5(ypObject **sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject *x);
-yp_func(c_void, "yp_setsliceC5", ((c_ypObject_pp, "sequence"),
-                                  (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), (c_yp_ssize_t, "k"), (c_ypObject_p, "x")))
+# void yp_delsliceC5(
+#         ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject **exc);
+yp_func(c_void, "yp_delsliceC5", ((c_ypObject_p, "sequence"),
+                                  (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), (c_yp_ssize_t, "k"), c_ypObject_pp_exc))
 
-# void yp_setitem(ypObject **sequence, ypObject *key, ypObject *x);
+# void yp_append(ypObject *sequence, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_append", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# void yp_delindexC(ypObject **sequence, yp_ssize_t i);
+# void yp_extend(ypObject *sequence, ypObject *t, ypObject **exc);
+yp_func(c_void, "yp_extend", ((c_ypObject_p, "sequence"), (c_ypObject_p, "t"), c_ypObject_pp_exc))
 
-# void yp_delsliceC4(ypObject **sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k);
-yp_func(c_void, "yp_delsliceC4", ((c_ypObject_pp, "sequence"),
-                                  (c_yp_ssize_t, "i"), (c_yp_ssize_t, "j"), (c_yp_ssize_t, "k")))
+# void yp_irepeatC(ypObject *sequence, yp_ssize_t factor, ypObject **exc);
+yp_func(c_void, "yp_irepeatC", ((c_ypObject_p, "sequence"), (c_yp_ssize_t, "factor"), c_ypObject_pp_exc))
 
-# void yp_delitem(ypObject **sequence, ypObject *key);
+# void yp_insertC(ypObject *sequence, yp_ssize_t i, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_insertC", ((c_ypObject_p, "sequence"),
+                               (c_yp_ssize_t, "i"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# void yp_append(ypObject **sequence, ypObject *x);
-# void yp_push(ypObject **sequence, ypObject *x);
-yp_func(c_void, "yp_append", ((c_ypObject_pp, "sequence"), (c_ypObject_p, "x")))
+# ypObject *yp_popindexC(ypObject *sequence, yp_ssize_t i);
+yp_func(c_ypObject_p, "yp_popindexC", ((c_ypObject_p, "sequence"), (c_yp_ssize_t, "i")))
 
-# void yp_extend(ypObject **sequence, ypObject *t);
-yp_func(c_void, "yp_extend", ((c_ypObject_pp, "sequence"), (c_ypObject_p, "t")))
+# void yp_remove(ypObject *sequence, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_remove", ((c_ypObject_p, "sequence"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# void yp_irepeatC(ypObject **sequence, yp_ssize_t factor);
-yp_func(c_void, "yp_irepeatC", ((c_ypObject_pp, "sequence"), (c_yp_ssize_t, "factor")))
+# void yp_reverse(ypObject *sequence, ypObject **exc);
+yp_func(c_void, "yp_reverse", ((c_ypObject_p, "sequence"), c_ypObject_pp_exc))
 
-# void yp_insertC(ypObject **sequence, yp_ssize_t i, ypObject *x);
-yp_func(c_void, "yp_insertC", ((c_ypObject_pp, "sequence"),
-                               (c_yp_ssize_t, "i"), (c_ypObject_p, "x")))
-
-# ypObject *yp_popindexC(ypObject **sequence, yp_ssize_t i);
-yp_func(c_ypObject_p, "yp_popindexC", ((c_ypObject_pp, "sequence"), (c_yp_ssize_t, "i")))
-
-# ypObject *yp_pop(ypObject **sequence);
-
-# void yp_remove(ypObject **sequence, ypObject *x);
-yp_func(c_void, "yp_remove", ((c_ypObject_pp, "sequence"), (c_ypObject_p, "x")))
-
-# void yp_reverse(ypObject **sequence);
-yp_func(c_void, "yp_reverse", ((c_ypObject_pp, "sequence"), ))
-
-# void yp_sort3(ypObject **sequence, ypObject *key, ypObject *reverse);
+# void yp_sort4(ypObject *sequence, ypObject *key, ypObject *reverse, ypObject **exc);
 yp_func(
-    c_void, "yp_sort3",
-    ((c_ypObject_pp, "sequence"), (c_ypObject_p, "key"), (c_ypObject_p, "reverse"))
+    c_void, "yp_sort4",
+    ((c_ypObject_p, "sequence"), (c_ypObject_p, "key"), (c_ypObject_p, "reverse"), c_ypObject_pp_exc)
 )
-
-# void yp_sort(ypObject **sequence);
 
 # define yp_SLICE_DEFAULT yp_SSIZE_T_MIN
 _yp_SLICE_DEFAULT = _yp_SSIZE_T_MIN
@@ -656,68 +496,51 @@ yp_func(c_ypObject_p, "yp_isdisjoint", ((c_ypObject_p, "set"), (c_ypObject_p, "x
 # ypObject *yp_issubset(ypObject *set, ypObject *x);
 yp_func(c_ypObject_p, "yp_issubset", ((c_ypObject_p, "set"), (c_ypObject_p, "x")))
 
-# ypObject *yp_lt(ypObject *set, ypObject *x);
-
 # ypObject *yp_issuperset(ypObject *set, ypObject *x);
 yp_func(c_ypObject_p, "yp_issuperset", ((c_ypObject_p, "set"), (c_ypObject_p, "x")))
 
-# ypObject *yp_gt(ypObject *set, ypObject *x);
-
 # ypObject *yp_unionN(ypObject *set, int n, ...);
-# ypObject *yp_unionNV(ypObject *set, int n, va_list args);
 yp_func(c_ypObject_p, "yp_unionN", ((c_ypObject_p, "set"), c_multiN_ypObject_p))
 
 # ypObject *yp_intersectionN(ypObject *set, int n, ...);
-# ypObject *yp_intersectionNV(ypObject *set, int n, va_list args);
 yp_func(c_ypObject_p, "yp_intersectionN", ((c_ypObject_p, "set"), c_multiN_ypObject_p))
 
 # ypObject *yp_differenceN(ypObject *set, int n, ...);
-# ypObject *yp_differenceNV(ypObject *set, int n, va_list args);
 yp_func(c_ypObject_p, "yp_differenceN", ((c_ypObject_p, "set"), c_multiN_ypObject_p))
 
 # ypObject *yp_symmetric_difference(ypObject *set, ypObject *x);
 yp_func(c_ypObject_p, "yp_symmetric_difference", ((c_ypObject_p, "set"), (c_ypObject_p, "x")))
 
-# void yp_updateN(ypObject **set, int n, ...);
-# void yp_updateNV(ypObject **set, int n, va_list args);
-yp_func(c_void, "yp_updateN", ((c_ypObject_pp, "set"), c_multiN_ypObject_p))
+# void yp_updateN(ypObject *set, ypObject **exc, int n, ...);
+yp_func(c_void, "yp_updateN", ((c_ypObject_p, "set"), c_ypObject_pp_exc, c_multiN_ypObject_p))
 
-# void yp_intersection_updateN(ypObject **set, int n, ...);
-# void yp_intersection_updateNV(ypObject **set, int n, va_list args);
-yp_func(c_void, "yp_intersection_updateN", ((c_ypObject_pp, "set"), c_multiN_ypObject_p))
+# void yp_intersection_updateN(ypObject *set, ypObject **exc, int n, ...);
+yp_func(c_void, "yp_intersection_updateN", ((c_ypObject_p, "set"), c_ypObject_pp_exc, c_multiN_ypObject_p))
 
-# void yp_difference_updateN(ypObject **set, int n, ...);
-# void yp_difference_updateNV(ypObject **set, int n, va_list args);
-yp_func(c_void, "yp_difference_updateN", ((c_ypObject_pp, "set"), c_multiN_ypObject_p))
+# void yp_difference_updateN(ypObject *set, ypObject **exc, int n, ...);
+yp_func(c_void, "yp_difference_updateN", ((c_ypObject_p, "set"), c_ypObject_pp_exc, c_multiN_ypObject_p))
 
-# void yp_symmetric_difference_update(ypObject **set, ypObject *x);
-yp_func(c_void, "yp_symmetric_difference_update", ((c_ypObject_pp, "set"), (c_ypObject_p, "x")))
+# void yp_symmetric_difference_update(ypObject *set, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_symmetric_difference_update", ((c_ypObject_p, "set"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# void yp_push(ypObject **set, ypObject *x);
-# void yp_set_add(ypObject **set, ypObject *x);
-yp_func(c_void, "yp_set_add", ((c_ypObject_pp, "set"), (c_ypObject_p, "x")))
+# void yp_set_add(ypObject *set, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_set_add", ((c_ypObject_p, "set"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# ypObject *yp_pushuniqueE(ypObject **set, ypObject *x);
-yp_func(c_void, "yp_pushuniqueE", ((c_ypObject_pp, "set"), (c_ypObject_p, "x")))
+# void yp_pushunique(ypObject *set, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_pushuniqueE", ((c_ypObject_p, "set"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# void yp_remove(ypObject **set, ypObject *x);
-# (declared above)
-
-# void yp_discard(ypObject **set, ypObject *x);
-yp_func(c_void, "yp_discard", ((c_ypObject_pp, "set"), (c_ypObject_p, "x")))
-
-# ypObject *yp_pop(ypObject **set);
-
+# void yp_discard(ypObject *set, ypObject *x, ypObject **exc);
+yp_func(c_void, "yp_discard", ((c_ypObject_p, "set"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
 # ypObject *yp_getitem(ypObject *mapping, ypObject *key);
 yp_func(c_ypObject_p, "yp_getitem", ((c_ypObject_p, "mapping"), (c_ypObject_p, "key")))
 
-# void yp_setitem(ypObject **mapping, ypObject *key, ypObject *x);
+# void yp_setitem(ypObject *mapping, ypObject *key, ypObject *x, ypObject **exc);
 yp_func(c_void, "yp_setitem",
-        ((c_ypObject_pp, "mapping"), (c_ypObject_p, "key"), (c_ypObject_p, "x")))
+        ((c_ypObject_p, "mapping"), (c_ypObject_p, "key"), (c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# void yp_delitem(ypObject **mapping, ypObject *key);
-yp_func(c_void, "yp_delitem", ((c_ypObject_pp, "mapping"), (c_ypObject_p, "key")))
+# void yp_delitem(ypObject *mapping, ypObject *key, ypObject **exc);
+yp_func(c_void, "yp_delitem", ((c_ypObject_p, "mapping"), (c_ypObject_p, "key"), c_ypObject_pp_exc))
 
 # ypObject *yp_getdefault(ypObject *mapping, ypObject *key, ypObject *defval);
 yp_func(c_ypObject_p, "yp_getdefault",
@@ -729,42 +552,23 @@ yp_func(c_ypObject_p, "yp_iter_items", ((c_ypObject_p, "mapping"), ))
 # ypObject *yp_iter_keys(ypObject *mapping);
 yp_func(c_ypObject_p, "yp_iter_keys", ((c_ypObject_p, "mapping"), ))
 
-# ypObject *yp_popvalue3(ypObject **mapping, ypObject *key, ypObject *defval);
-yp_func(c_ypObject_p, "yp_popvalue3", ((c_ypObject_pp, "mapping"), (c_ypObject_p, "key"),
+# ypObject *yp_popvalue3(ypObject *mapping, ypObject *key, ypObject *defval);
+yp_func(c_ypObject_p, "yp_popvalue3", ((c_ypObject_p, "mapping"), (c_ypObject_p, "key"),
                                        (c_ypObject_p, "defval")))
 
-# void yp_popitem(ypObject **mapping, ypObject **key, ypObject **value);
-yp_func(c_void, "yp_popitem", ((c_ypObject_pp, "mapping"), (c_ypObject_pp, "key"),
+# void yp_popitem(ypObject *mapping, ypObject **key, ypObject **value);
+yp_func(c_void, "yp_popitem", ((c_ypObject_p, "mapping"), (c_ypObject_pp, "key"),
                                (c_ypObject_pp, "value")))
 
-# ypObject *yp_setdefault(ypObject **mapping, ypObject *key, ypObject *defval);
+# ypObject *yp_setdefault(ypObject *mapping, ypObject *key, ypObject *defval);
 yp_func(c_ypObject_p, "yp_setdefault",
-        ((c_ypObject_pp, "mapping"), (c_ypObject_p, "key"), (c_ypObject_p, "defval")))
+        ((c_ypObject_p, "mapping"), (c_ypObject_p, "key"), (c_ypObject_p, "defval")))
 
-# void yp_updateK(ypObject **mapping, int n, ...);
-# void yp_updateKV(ypObject **mapping, int n, va_list args);
-yp_func(c_void, "yp_updateK", ((c_ypObject_pp, "mapping"), c_multiK_ypObject_p))
-
-# void yp_updateN(ypObject **mapping, int n, ...);
-# void yp_updateNV(ypObject **mapping, int n, va_list args);
+# void yp_updateK(ypObject *mapping, ypObject **exc, int n, ...);
+yp_func(c_void, "yp_updateK", ((c_ypObject_p, "mapping"), c_ypObject_pp_exc, c_multiK_ypObject_p))
 
 # ypObject *yp_iter_values(ypObject *mapping);
 yp_func(c_ypObject_p, "yp_iter_values", ((c_ypObject_p, "mapping"), ))
-
-
-# ypObject *yp_s_ascii;     // "ascii"
-# ypObject *yp_s_latin_1;   // "latin_1"
-# ypObject *yp_s_utf_32;    // "utf_32"
-# ypObject *yp_s_utf_32_be; // "utf_32_be"
-# ypObject *yp_s_utf_32_le; // "utf_32_le"
-# ypObject *yp_s_utf_16;    // "utf_16"
-# ypObject *yp_s_utf_16_be; // "utf_16_be"
-# ypObject *yp_s_utf_16_le; // "utf_16_le"
-# ypObject *yp_s_utf_8;     // "utf_8"
-
-# ypObject *yp_s_strict;    // "strict"
-# ypObject *yp_s_ignore;    // "ignore"
-# ypObject *yp_s_replace;   // "replace"
 
 # ypObject *yp_isalnum(ypObject *s);
 yp_func(c_ypObject_p, "yp_isalnum", ((c_ypObject_p, "s"), ))
@@ -873,12 +677,6 @@ yp_func(c_ypObject_p, "yp_join", ((c_ypObject_p, "s"), (c_ypObject_p, "iterable"
 # ypObject *yp_joinNV(ypObject *s, int n, va_list args);
 yp_func(c_ypObject_p, "yp_joinN", ((c_ypObject_p, "s"), c_multiN_ypObject_p))
 
-# void yp_partition(ypObject *s, ypObject *sep,
-#        ypObject **part0, ypObject **part1, ypObject **part2);
-
-# void yp_rpartition(ypObject *s, ypObject *sep,
-#        ypObject **part0, ypObject **part1, ypObject **part2);
-
 # ypObject *yp_splitC3(ypObject *s, ypObject *sep, yp_ssize_t maxsplit);
 # ypObject *yp_split2(ypObject *s, ypObject *sep);
 yp_func(c_ypObject_p, "yp_splitC3", ((c_ypObject_p, "s"), (c_ypObject_p, "sep"),
@@ -907,12 +705,7 @@ yp_func(c_ypObject_p, "yp_decode3", ((c_ypObject_p, "b"),
                                      (c_ypObject_p, "encoding"), (c_ypObject_p, "errors")))
 yp_func(c_ypObject_p, "yp_decode", ((c_ypObject_p, "b"), ))
 
-# FIXME String Formatting Operations
-
-# int yp_iscallableC(ypObject *x);
-
 # ypObject *yp_callN(ypObject *c, int n, ...);
-# ypObject *yp_callNV(ypObject *c, int n, va_list args);
 yp_func(c_ypObject_p, "yp_callN", ((c_ypObject_p, "c"), c_multiN_ypObject_p))
 
 # ypObject *yp_call_stars(ypObject *c, ypObject *args, ypObject *kwargs);
@@ -956,149 +749,16 @@ yp_func(c_ypObject_p, "yp_abs", ((c_ypObject_p, "x"), ))
 # ypObject *yp_invert(ypObject *x);
 yp_func(c_ypObject_p, "yp_invert", ((c_ypObject_p, "x"), ))
 
-# void yp_iadd(ypObject **x, ypObject *y);
-# void yp_isub(ypObject **x, ypObject *y);
-# void yp_imul(ypObject **x, ypObject *y);
-# void yp_itruediv(ypObject **x, ypObject *y);
-# void yp_ifloordiv(ypObject **x, ypObject *y);
-# void yp_imod(ypObject **x, ypObject *y);
-# void yp_ipow(ypObject **x, ypObject *y);
-# void yp_ipow4(ypObject **x, ypObject *y, ypObject *z);
-# void yp_ilshift(ypObject **x, ypObject *y);
-# void yp_irshift(ypObject **x, ypObject *y);
-# void yp_iamp(ypObject **x, ypObject *y);
-# void yp_ixor(ypObject **x, ypObject *y);
-# void yp_ibar(ypObject **x, ypObject *y);
-# void yp_ineg(ypObject **x);
-# void yp_ipos(ypObject **x);
-# void yp_iabs(ypObject **x);
-# void yp_iinvert(ypObject **x);
-
-# void yp_iaddC(ypObject **x, yp_int_t y);
-# void yp_isubC(ypObject **x, yp_int_t y);
-# void yp_imulC(ypObject **x, yp_int_t y);
-# void yp_itruedivC(ypObject **x, yp_int_t y);
-# void yp_ifloordivC(ypObject **x, yp_int_t y);
-# void yp_imodC(ypObject **x, yp_int_t y);
-# void yp_ipowC(ypObject **x, yp_int_t y);
-# void yp_ipowC4(ypObject **x, yp_int_t y, yp_int_t z);
-# void yp_ilshiftC(ypObject **x, yp_int_t y);
-# void yp_irshiftC(ypObject **x, yp_int_t y);
-# void yp_iampC(ypObject **x, yp_int_t y);
-# void yp_ixorC(ypObject **x, yp_int_t y);
-# void yp_ibarC(ypObject **x, yp_int_t y);
-
-# void yp_iaddCF(ypObject **x, yp_float_t y);
-# void yp_isubCF(ypObject **x, yp_float_t y);
-# void yp_imulCF(ypObject **x, yp_float_t y);
-# void yp_itruedivCF(ypObject **x, yp_float_t y);
-# void yp_ifloordivCF(ypObject **x, yp_float_t y);
-# void yp_imodCF(ypObject **x, yp_float_t y);
-# void yp_ipowCF(ypObject **x, yp_float_t y);
-# void yp_ilshiftCF(ypObject **x, yp_float_t y);
-# void yp_irshiftCF(ypObject **x, yp_float_t y);
-# void yp_iampCF(ypObject **x, yp_float_t y);
-# void yp_ixorCF(ypObject **x, yp_float_t y);
-# void yp_ibarCF(ypObject **x, yp_float_t y);
-
-# yp_int_t yp_addL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_subL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_mulL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_truedivL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_floordivL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_modL(yp_int_t x, yp_int_t y, ypObject **exc);
-# void yp_divmodL(yp_int_t x, yp_int_t y, yp_int_t *div, yp_int_t *mod, ypObject **exc);
-# yp_int_t yp_powL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_powL4(yp_int_t x, yp_int_t y, yp_int_t z, ypObject **exc);
-# yp_int_t yp_lshiftL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_rshiftL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_ampL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_xorL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_barL(yp_int_t x, yp_int_t y, ypObject **exc);
-# yp_int_t yp_negL(yp_int_t x, ypObject **exc);
-# yp_int_t yp_posL(yp_int_t x, ypObject **exc);
-# yp_int_t yp_absL(yp_int_t x, ypObject **exc);
-# yp_int_t yp_invertL(yp_int_t x, ypObject **exc);
-
-# yp_float_t yp_addLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_subLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_mulLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_truedivLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_floordivLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_modLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# void yp_divmodLF(yp_float_t x, yp_float_t y, yp_float_t *div, yp_float_t *mod, ypObject **exc);
-# yp_float_t yp_powLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_lshiftLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_rshiftLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_ampLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_xorLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_barLF(yp_float_t x, yp_float_t y, ypObject **exc);
-# yp_float_t yp_negLF(yp_float_t x, ypObject **exc);
-# yp_float_t yp_posLF(yp_float_t x, ypObject **exc);
-# yp_float_t yp_absLF(yp_float_t x, ypObject **exc);
-# yp_float_t yp_invertLF(yp_float_t x, ypObject **exc);
-
 # yp_int_t yp_asintC(ypObject *x, ypObject **exc);
 yp_func(c_yp_int_t, "yp_asintC", ((c_ypObject_p, "x"), c_ypObject_pp_exc))
-# yp_int8_t yp_asint8C(ypObject *x, ypObject **exc);
-# yp_uint8_t yp_asuint8C(ypObject *x, ypObject **exc);
-# yp_int16_t yp_asint16C(ypObject *x, ypObject **exc);
-# yp_uint16_t yp_asuint16C(ypObject *x, ypObject **exc);
-# yp_int32_t yp_asint32C(ypObject *x, ypObject **exc);
-# yp_uint32_t yp_asuint32C(ypObject *x, ypObject **exc);
-# yp_int64_t yp_asint64C(ypObject *x, ypObject **exc);
-# yp_uint64_t yp_asuint64C(ypObject *x, ypObject **exc);
 # yp_float_t yp_asfloatC(ypObject *x, ypObject **exc);
 yp_func(c_yp_float_t, "yp_asfloatC", ((c_ypObject_p, "x"), c_ypObject_pp_exc))
-# yp_float32_t yp_asfloat32C(ypObject *x, ypObject **exc);
-# yp_float64_t yp_asfloat64C(ypObject *x, ypObject **exc);
-# yp_float_t yp_asfloatL(yp_int_t x, ypObject **exc);
-# yp_int_t yp_asintLF(yp_float_t x, ypObject **exc);
-
-# ypObject *yp_roundC(ypObject *x, int ndigits);
-
-# ypObject *yp_sumN(int n, ...);
-# ypObject *yp_sumNV(int n, va_list args);
-
-# ypObject *yp_sum(ypObject *iterable);
 
 # yp_int_t yp_int_bit_lengthC(ypObject *x, ypObject **exc);
 yp_func(c_yp_int_t, "yp_int_bit_lengthC", ((c_ypObject_p, "x"), c_ypObject_pp_exc))
 
-# ypObject * const yp_sys_maxint;
-# ypObject * const yp_sys_minint;
-
-# ypObject * const yp_i_neg_one;
-# ypObject * const yp_i_zero;
-# ypObject * const yp_i_one;
-# ypObject * const yp_i_two;
-
-
 # ypObject *yp_type(ypObject *object);
 yp_func(c_ypObject_p, "yp_type", ((c_ypObject_p, "object"), ))
-
-# ypObject * const yp_t_invalidated;
-# ypObject * const yp_t_exception;
-# ypObject * const yp_t_type;
-# ypObject * const yp_t_NoneType;
-# ypObject * const yp_t_bool;
-# ypObject * const yp_t_int;
-# ypObject * const yp_t_intstore;
-# ypObject * const yp_t_float;
-# ypObject * const yp_t_floatstore;
-# ypObject * const yp_t_iter;
-# ypObject * const yp_t_bytes;
-# ypObject * const yp_t_bytearray;
-# ypObject * const yp_t_str;
-# ypObject * const yp_t_chrarray;
-# ypObject * const yp_t_tuple;
-# ypObject * const yp_t_list;
-# ypObject * const yp_t_frozenset;
-# ypObject * const yp_t_set;
-# ypObject * const yp_t_frozendict;
-# ypObject * const yp_t_dict;
-# ypObject * const yp_t_range;
-
 
 # ypObject *yp_asbytesCX(ypObject *seq, const yp_uint8_t * *bytes, yp_ssize_t *len);
 yp_func(c_ypObject_p, "yp_asbytesCX", ((c_ypObject_p, "seq"),
@@ -1109,8 +769,6 @@ yp_func(c_ypObject_p, "yp_asbytesCX", ((c_ypObject_p, "seq"),
 yp_func(c_ypObject_p, "yp_asencodedCX", ((c_ypObject_p, "seq"),
                                          (c_char_pp, "encoded"), (c_yp_ssize_t_p, "size"), (c_ypObject_pp, "encoding")),
         errcheck=False)
-
-# ypObject *yp_itemarrayCX(ypObject *seq, ypObject * const * *array, yp_ssize_t *len);
 
 
 _ypExc2py = {}

--- a/nohtyP.c
+++ b/nohtyP.c
@@ -16,9 +16,9 @@
 
 // TODO Audit the use of leading underscore and ensure consistency
 
-// TODO A flag on (immutable) objects to verify the stored hash.  Flag is set when internal
+// TODO A flag on (immutable) objects to verify the stored hash. Flag is set when internal
 // pointers are returned (think yp_asencodedCX), then verified/cleared when yp_hash/currenthash is
-// called again.  Provides a safeguard against this internal data being modified.
+// called again. Provides a safeguard against this internal data being modified.
 
 // TODO what do we gain by caching the hash?  We already jump through hoops to use the hash
 // stored in the hash table where possible.
@@ -37,7 +37,7 @@
 // TODO Use NotImplemented, instead of NotImplementedError, as per Python.
 
 // TODO Look for all the places yp_decref, yp_eq, and others might execute arbitrary code that
-// might modify the object being iterated over.  OR  Add some sort of universal flag to objects to
+// might modify the object being iterated over. OR  Add some sort of universal flag to objects to
 // prevent modifications.
 
 // TODO Look for places we use a borrowed reference from an object and then call arbitrary code:
@@ -362,7 +362,7 @@ typedef enum { yp_FIND_FORWARD, yp_FIND_REVERSE } findfunc_direction;
 typedef ypObject *(*findfunc)(
         ypObject *, ypObject *, yp_ssize_t, yp_ssize_t, findfunc_direction, yp_ssize_t *);
 
-// Suite of number methods.  A placeholder for now, as the current implementation doesn't allow
+// Suite of number methods. A placeholder for now, as the current implementation doesn't allow
 // overriding yp_add et al (TODO).
 typedef struct {
     objproc _placeholder;
@@ -646,7 +646,7 @@ yp_STATIC_ASSERT(_ypFunction_CODE == ypFunction_CODE, ypFunction_CODE_matches);
 
 DEFINE_GENERIC_METHODS(MethodError, yp_MethodError);  // for methods the type doesn't support
 // TODO A yp_ImmutableTypeError, subexception of yp_TypeError, for methods that are supported only
-// by the mutable version.  Then, add a debug yp_initialize assert to ensure all type tables uses
+// by the mutable version. Then, add a debug yp_initialize assert to ensure all type tables uses
 // this appropriately.
 DEFINE_GENERIC_METHODS(TypeError, yp_TypeError);
 DEFINE_GENERIC_METHODS(InvalidatedError, yp_InvalidatedError);  // for Invalidated objects
@@ -749,10 +749,10 @@ int yp_isexceptionC(ypObject *x) { return yp_IS_EXCEPTION_C(x); }
 #define yp_offsetof(structType, member) ((yp_ssize_t)offsetof(structType, member))
 #define yp_sizeof_member(structType, member) yp_sizeof(((structType *)0)->member)
 
-// Length of an array.  Only call for arrays of fixed size that haven't been coerced to pointers.
+// Length of an array. Only call for arrays of fixed size that haven't been coerced to pointers.
 #define yp_lengthof_array(x) (yp_sizeof(x) / yp_sizeof(x[0]))
 
-// Length of an array in a structure.  Only call for arrays of fixed size.
+// Length of an array in a structure. Only call for arrays of fixed size.
 #define yp_lengthof_array_member(structType, member) yp_lengthof_array(((structType *)0)->member)
 
 // Versions of memcmp/etc that don't warn about yp_ssize_t mismatches.
@@ -762,7 +762,7 @@ int yp_isexceptionC(ypObject *x) { return yp_IS_EXCEPTION_C(x); }
 #define yp_memset(x, c, l) (memset((x), (c), (size_t)(l)))
 
 // XXX Adapted from _Py_SIZE_ROUND_DOWN et al
-// Below "a" is a power of 2.  Round down size "n" to be a multiple of "a".
+// Below "a" is a power of 2. Round down size "n" to be a multiple of "a".
 #define yp_SIZE_ROUND_DOWN(n, a) ((size_t)(n) & ~(size_t)((a)-1))
 // Round up size "n" to be a multiple of "a".
 #define yp_SIZE_ROUND_UP(n, a) (((size_t)(n) + (size_t)((a)-1)) & ~(size_t)((a)-1))
@@ -824,7 +824,7 @@ yp_STATIC_ASSERT(yp_sizeof(_yp_uint_t) == yp_sizeof(yp_int_t), sizeof_yp_uint_eq
 // XXX Adapted from Python's _PyHASH_MULTIPLIER
 #define _ypHASH_MULTIPLIER 1000003  // 0xf4243
 
-// Parameters used for the numeric hash implementation.  Numeric hashes are based on reduction
+// Parameters used for the numeric hash implementation. Numeric hashes are based on reduction
 // modulo the prime 2**_PyHASH_BITS - 1.
 // XXX Adapted from Python's pyport.h
 #if defined(yp_ARCH_32_BIT)
@@ -1506,7 +1506,7 @@ const yp_uint8_t _yp_ctype_toupper[256] = {
 //  - malloc/realloc may allocate more memory than requested, memory that _could_ be used if we
 //  only knew how much there was
 // yp_malloc, yp_malloc_resize, and yp_free are the top level functions of nohtyP's memory
-// allocation scheme, designed to overcome these inefficiencies.  There are several implementations
+// allocation scheme, designed to overcome these inefficiencies. There are several implementations
 // of these APIs depending on the target platform; you can also provide your own versions via
 // yp_initialize.
 
@@ -1633,7 +1633,7 @@ yp_STATIC_ASSERT(yp_sizeof(_ypMem_starting_refcnt) == yp_sizeof_member(ypObject,
         sizeof_starting_refcnt);
 
 // When calculating the number of required bytes, there is protection at higher levels to ensure
-// the multiplication never overflows.  However, when calculating extra (or required+extra) bytes,
+// the multiplication never overflows. However, when calculating extra (or required+extra) bytes,
 // if the multiplication overflows we clamp to yp_SSIZE_T_MAX.
 static yp_ssize_t _ypMem_calc_extra_size(yp_ssize_t alloclen, yp_ssize_t elemsize)
 {
@@ -1662,9 +1662,9 @@ static ypObject *_ypMem_malloc_fixed(int type, yp_ssize_t sizeof_obStruct)
 #define ypMem_MALLOC_FIXED(obStruct, type) _ypMem_malloc_fixed((type), yp_sizeof(obStruct))
 
 // Returns a malloc'd buffer for a container object holding alloclen elements in-line, or exception
-// on failure.  The container can neither grow nor shrink after allocation.  ob_inline_data in
-// obStruct is used to determine the element size and ob_data; ob_len is set to zero.  alloclen
-// must not be negative and offsetof_inline+(alloclen*elemsize) must not overflow.  ob_alloclen may
+// on failure. The container can neither grow nor shrink after allocation. ob_inline_data in
+// obStruct is used to determine the element size and ob_data; ob_len is set to zero. alloclen
+// must not be negative and offsetof_inline+(alloclen*elemsize) must not overflow. ob_alloclen may
 // be larger than requested, but will never be larger than alloclen_max.
 static ypObject *_ypMem_malloc_container_inline(int type, yp_ssize_t alloclen,
         yp_ssize_t alloclen_max, yp_ssize_t offsetof_inline, yp_ssize_t elemsize)
@@ -1715,9 +1715,9 @@ static ypObject *_ypMem_malloc_container_inline(int type, yp_ssize_t alloclen,
 static yp_ssize_t _ypMem_ideal_size = _ypMem_ideal_size_DEFAULT;
 
 // Returns a malloc'd buffer for a container that may grow or shrink in the future, or exception on
-// failure.  A fixed amount of memory is allocated in-line, as per _ypMem_ideal_size.  If this fits
+// failure. A fixed amount of memory is allocated in-line, as per _ypMem_ideal_size. If this fits
 // required elements, it is used, otherwise a separate buffer of required+extra elements is
-// allocated.  required and extra must not be negative and required*elemsize must not overflow.
+// allocated. required and extra must not be negative and required*elemsize must not overflow.
 // ob_alloclen may be larger than requested, but will never be larger than alloclen_max.
 static yp_ssize_t _ypMem_inlinelen_container_variable(
         yp_ssize_t offsetof_inline, yp_ssize_t elemsize);
@@ -1787,7 +1787,7 @@ static yp_ssize_t _ypMem_inlinelen_container_variable(
             (ob), obStruct, yp_sizeof_member(obStruct, ob_inline_data[0]))
 
 // Resizes ob_data, the variable-portion of ob, and returns the previous value of ob_data
-// ("oldptr").  There are three possible scenarios:
+// ("oldptr"). There are three possible scenarios:
 //  - On error, returns NULL, and ob is not modified
 //  - If ob_data can be resized in-place, updates ob_alloclen and returns ob_data; in this case, no
 //  memcpy is necessary, as the buffer has not moved
@@ -1795,10 +1795,10 @@ static yp_ssize_t _ypMem_inlinelen_container_variable(
 //  will need to copy the data from oldptr, then free it with:
 //      ypMem_REALLOC_CONTAINER_FREE_OLDPTR(ob, obStruct, oldptr)
 // Required is the minimum ob_alloclen required; if required can fit inline, the inline buffer is
-// used.  extra is a hint as to how much the buffer should be over-allocated, which may be ignored.
+// used. extra is a hint as to how much the buffer should be over-allocated, which may be ignored.
 // This function will always resize the data, so first check to see if a resize is necessary.
-// required and extra must not be negative and required*elemsize must not overflow.  ob_alloclen
-// may be larger than requested, but will never be larger than alloclen_max.  Does not update
+// required and extra must not be negative and required*elemsize must not overflow. ob_alloclen
+// may be larger than requested, but will never be larger than alloclen_max. Does not update
 // ob_len.
 // XXX Unlike realloc, this *never* copies to the new buffer and *never* frees the old buffer.
 static void *_ypMem_realloc_container_variable(ypObject *ob, yp_ssize_t required, yp_ssize_t extra,
@@ -1941,8 +1941,8 @@ static void _ypMem_realloc_container_free_oldptr(
 #define ypMem_REALLOC_CONTAINER_FREE_OLDPTR(ob, obStruct, oldptr) \
     _ypMem_realloc_container_free_oldptr((ob), oldptr, yp_offsetof(obStruct, ob_inline_data))
 
-// Resets ob_data to the inline buffer and frees the separate buffer (if there is one).  Any
-// contained objects must have already been discarded; no memory is copied.  Always succeeds.
+// Resets ob_data to the inline buffer and frees the separate buffer (if there is one). Any
+// contained objects must have already been discarded; no memory is copied. Always succeeds.
 // TODO Is it actually a good idea to free the buffer on clear? If the object grows again, we will
 // need a new buffer, and isn't it a fair assumption that a reused object will be about the same
 // size every time? We should have consistency and guidance in the documentation.
@@ -2012,7 +2012,7 @@ void yp_increfN(int n, ...)
 }
 
 // FIXME This ypObject_dealloclist support should be available externally as part of nohtyP.h,
-// so that custom objects can also delay deallocation until the end of their methods.  Will need to
+// so that custom objects can also delay deallocation until the end of their methods. Will need to
 // think hard about the names these should be given, and which parts of the API should be opaque.
 typedef struct {
     ypObject *head;
@@ -2029,7 +2029,7 @@ static void _ypObject_dealloclist_push(ypObject_dealloclist *list, ypObject *x)
     yp_ASSERT1(list != NULL);
     yp_ASSERT1(ypObject_REFCNT(x) == 1);
 
-    // We abuse ob_hash to form a linked list of objects to deallocate.  This is safe since we
+    // We abuse ob_hash to form a linked list of objects to deallocate. This is safe since we
     // alone hold the last remaining reference, and as such no other code should access this field.
     ypObject_CACHED_HASH(x) = (yp_hash_t)NULL;
     if (list->head == NULL) {
@@ -2054,7 +2054,7 @@ static ypObject *_ypObject_dealloclist_pop(ypObject_dealloclist *list)
         return NULL;
     }
 
-    // We abuse ob_hash to form a linked list of objects to deallocate.  Because deallocating x
+    // We abuse ob_hash to form a linked list of objects to deallocate. Because deallocating x
     // will run arbitrary code that may depend on ob_hash, we invalidate ob_hash before returning.
     if (x == list->tail) {
         list->head = NULL;
@@ -2115,12 +2115,12 @@ static void yp_decref_fromdealloc(ypObject *x, void *memo)
     }
 }
 
-// TODO A version of decref that returns exceptions.  Objects that could fail deallocation need to
+// TODO A version of decref that returns exceptions. Objects that could fail deallocation need to
 // ensure they are in a consistent state when returning...perhaps the deallocation can be attempted
 // again and it will skip over the part that failed?  Still need yp_decref to squelch errors, but
 // an ASSERT on error is not enough: in testing, an exception would have to be raised in a debug
-// build for anybody to notice.  Instead, certain types (i.e. file) would need to require that
-// the exception-returning version is used.  If tp_dealloc took a ypObject**exc that yp_decref set
+// build for anybody to notice. Instead, certain types (i.e. file) would need to require that
+// the exception-returning version is used. If tp_dealloc took a ypObject**exc that yp_decref set
 // to NULL but yp_decrefE didn't, then file could ASSERT on the NULL and the user would know to use
 // the exception-returning version.
 void yp_decref(ypObject *x)
@@ -2154,8 +2154,8 @@ void yp_decrefN(int n, ...)
 // consolidate or simplify some code by using this API
 
 // This API exists to reduce duplication of code where variants of a method accept va_lists of
-// ypObject*s, or a general-purpose iterable.  This code intends to be a light-weight abstraction
-// over all of these, but particularly efficient for va_lists.  In particular, it doesn't require
+// ypObject*s, or a general-purpose iterable. This code intends to be a light-weight abstraction
+// over all of these, but particularly efficient for va_lists. In particular, it doesn't require
 // a temporary tuple to be allocated.
 //
 // Be very careful how you use this API, as only the bare-minimum safety checks are implemented.
@@ -2196,15 +2196,15 @@ typedef struct {
     // empty tuple if the iterator is exhausted. Exhausts the iterator, even on error.
     ypObject *(*remaining_as_tuple)(ypQuickIter_state *state);
 
-    // Returns the number of items left to be yielded.  Sets *isexact to true if this is an exact
-    // value, or false if this is an estimate.  On error, sets *exc, returns zero, and *isexact is
+    // Returns the number of items left to be yielded. Sets *isexact to true if this is an exact
+    // value, or false if this is an estimate. On error, sets *exc, returns zero, and *isexact is
     // undefined.
     // TODO Do like Python, and instead of *isexact accept a default hint that is returned?
     // There's also the idea of a ypObject_MIN_LENHINT...
     // FIXME Instead, return an error, take a pointer to the hint.
     yp_ssize_t (*length_hint)(ypQuickIter_state *state, int *isexact, ypObject **exc);
 
-    // Closes the ypQuickIter.  Any further operations on state will be undefined.
+    // Closes the ypQuickIter. Any further operations on state will be undefined.
     // TODO If any of these close methods raise errors, we'll need to return them
     void (*close)(ypQuickIter_state *state);
 } ypQuickIter_methods;
@@ -2249,8 +2249,8 @@ static const ypQuickIter_methods ypQuickIter_var_methods = {
         ypQuickIter_var_close                // close
 };
 
-// Initializes state with the given va_list containing n ypObject*s.  Always succeeds.  Use
-// ypQuickIter_var_methods as the method table.  The QuickIter is only valid so long as args is.
+// Initializes state with the given va_list containing n ypObject*s. Always succeeds. Use
+// ypQuickIter_var_methods as the method table. The QuickIter is only valid so long as args is.
 static void ypQuickIter_new_fromvar(ypQuickIter_state *state, int n, va_list args)
 {
     yp_ASSERT1(n >= 0);
@@ -2306,7 +2306,7 @@ static const ypQuickIter_methods ypQuickIter_array_methods = {
         ypQuickIter_array_close                // close
 };
 
-// Initializes state with the given array containing n ypObject*s. Always succeeds.  Use
+// Initializes state with the given array containing n ypObject*s. Always succeeds. Use
 // ypQuickIter_array_methods as the method table. The QuickIter is only valid so long as array is.
 static void ypQuickIter_new_fromarray(
         ypQuickIter_state *state, yp_ssize_t n, ypObject *const *array)
@@ -2382,8 +2382,8 @@ static const ypQuickIter_methods ypQuickIter_mi_methods = {
 
 
 // Initializes state to iterate over the given iterable, sets *methods to the proper method
-// table to use, and returns yp_None.  On error, returns an exception, and *methods and state are
-// undefined.  iterable is borrowed by state and must not be freed until methods->close is called.
+// table to use, and returns yp_None. On error, returns an exception, and *methods and state are
+// undefined. iterable is borrowed by state and must not be freed until methods->close is called.
 static ypObject *ypQuickIter_new_fromiterable(
         const ypQuickIter_methods **methods, ypQuickIter_state *state, ypObject *iterable)
 {
@@ -2417,14 +2417,14 @@ static ypObject *ypQuickIter_new_fromiterable(
 #pragma region ypQuickSeq
 
 // This API exists to reduce duplication of code where variants of a method accept va_lists of
-// ypObject*s, or a general-purpose sequence.  This code intends to be a light-weight abstraction
-// over all of these, but particularly efficient for va_lists accessed by increasing index.  That
+// ypObject*s, or a general-purpose sequence. This code intends to be a light-weight abstraction
+// over all of these, but particularly efficient for va_lists accessed by increasing index. That
 // last point is important: using a lower index than previously may incur a performance hit, as
 // the va_list will need to be va_end'ed, then va_copy'ed from the original, to get back to
-// index 0.  If you need random access to the va_list, consider first converting to a tuple.
+// index 0. If you need random access to the va_list, consider first converting to a tuple.
 //
 // Additionally, this API can be used in places where an iterable would normally be converted into
-// a tuple.  Similar to va_lists, set and dict can "index" their elements in increasing order, but
+// a tuple. Similar to va_lists, set and dict can "index" their elements in increasing order, but
 // will incur a performance hit if acccessed out-of-order.
 //
 // Be very careful how you use this API, as only the bare-minimum safety checks are implemented.
@@ -2450,16 +2450,16 @@ typedef union {
 // The various ypQuickSeq_new_* calls either correspond with, or return a pointer to, one of
 // these method tables, which is used to manipulate the associated ypQuickSeq_state.
 typedef struct {
-    // Returns a *borrowed* reference to the object at index i, or an exception.  If the index is
-    // out-of-range, returns NULL; negative indices are not allowed.  The borrowed reference
+    // Returns a *borrowed* reference to the object at index i, or an exception. If the index is
+    // out-of-range, returns NULL; negative indices are not allowed. The borrowed reference
     // becomes invalid when a new value is retrieved or close is called.
     ypObject *(*getindexX)(ypQuickSeq_state *state, yp_ssize_t i);
     // Similar to getindexX, but returns a new reference (that will remain valid until decref'ed).
     ypObject *(*getindex)(ypQuickSeq_state *state, yp_ssize_t i);
-    // Returns the total number of elements in the ypQuickSeq.  On error, sets *exc and returns
+    // Returns the total number of elements in the ypQuickSeq. On error, sets *exc and returns
     // zero.
     yp_ssize_t (*len)(ypQuickSeq_state *state, ypObject **exc);
-    // Closes the ypQuickSeq.  Any further operations on state will be undefined.
+    // Closes the ypQuickSeq. Any further operations on state will be undefined.
     // TODO If any of these close methods raise errors, we'll need to return them
     void (*close)(ypQuickSeq_state *state);
 } ypQuickSeq_methods;
@@ -2470,7 +2470,7 @@ static ypObject *ypQuickSeq_var_getindexX(ypQuickSeq_state *state, yp_ssize_t i)
     yp_ASSERT(i >= 0, "negative indices not allowed in ypQuickSeq");
     if (i >= state->var.len) return NULL;
 
-    // To go backwards, we have to restart state->var.args.  Note that if state->var.len is zero,
+    // To go backwards, we have to restart state->var.args. Note that if state->var.len is zero,
     // then we've already returned NULL before reaching this code.
     if (i < state->var.i) {
         va_end(state->var.args);
@@ -2510,8 +2510,8 @@ static const ypQuickSeq_methods ypQuickSeq_var_methods = {
         ypQuickSeq_var_close       // close
 };
 
-// Initializes state with the given va_list containing n ypObject*s.  Always succeeds.  Use
-// ypQuickSeq_var_methods as the method table.  The QuickSeq is only valid so long as args is.
+// Initializes state with the given va_list containing n ypObject*s. Always succeeds. Use
+// ypQuickSeq_var_methods as the method table. The QuickSeq is only valid so long as args is.
 static void ypQuickSeq_new_fromvar(ypQuickSeq_state *state, int n, va_list args)
 {
     state->var.len = MAX(n, 0);
@@ -2569,7 +2569,7 @@ static const ypQuickSeq_methods ypQuickSeq_seq_methods = {
 
 
 // Returns true if sequence is a supported built-in sequence object, in which case *methods and
-// state are initialized.  Cannot fail, but if sequence is not supported this returns false.
+// state are initialized. Cannot fail, but if sequence is not supported this returns false.
 // XXX The "built-in" distinction is important because we know that getindex will behave sanely
 static int ypQuickSeq_new_fromsequence_builtins(
         const ypQuickSeq_methods **methods, ypQuickSeq_state *state, ypObject *sequence)
@@ -2584,7 +2584,7 @@ static int ypQuickSeq_new_fromsequence_builtins(
 }
 
 // Initializes state with the given sequence, sets *methods to the proper method table to use, and
-// returns yp_None.  On error, returns an exception, and *methods and state are undefined.
+// returns yp_None. On error, returns an exception, and *methods and state are undefined.
 // sequence is borrowed by state and must not be freed until methods->close is called.
 static ypObject *ypQuickSeq_new_fromsequence(
         const ypQuickSeq_methods **methods, ypQuickSeq_state *state, ypObject *sequence)
@@ -2611,7 +2611,7 @@ static ypObject *ypQuickSeq_new_fromsequence(
 
 
 // Returns true if iterable is a supported built-in iterable object, in which case *methods and
-// state are initialized.  Cannot fail, but if iterable is not supported this returns false.
+// state are initialized. Cannot fail, but if iterable is not supported this returns false.
 // XXX The "built-in" distinction is important because we know that getindex will behave sanely
 static int ypQuickSeq_new_fromiterable_builtins(
         const ypQuickSeq_methods **methods, ypQuickSeq_state *state, ypObject *iterable)
@@ -2656,7 +2656,7 @@ static ypObject *_ypState_traverse(void *state, yp_uint32_t objlocs, visitfunc v
     }
 }
 
-// objlocs: bit n is 1 if (n*yp_sizeof(ypObject *)) is the offset of an object in state.  On error,
+// objlocs: bit n is 1 if (n*yp_sizeof(ypObject *)) is the offset of an object in state. On error,
 // *size and *objlocs are undefined.
 static ypObject *_ypState_fromdecl(
         yp_ssize_t *size, yp_uint32_t *objlocs, yp_state_decl_t *state_decl)
@@ -2682,7 +2682,7 @@ static ypObject *_ypState_fromdecl(
     }
     if (state_decl->offsets_len < 0) return yp_ValueError;
 
-    // Determine the location of the objects.  There are a few errors the user could make:
+    // Determine the location of the objects. There are a few errors the user could make:
     //  - an offset for a ypObject* that is at least partially outside of state
     //  - an unaligned ypObject*, which isn't currently allowed and should never happen
     //  - a larger offset than we can represent with objlocs: a current limitation of nohtyP
@@ -2787,8 +2787,8 @@ static ypObject *iter_close(ypObject *i)
     ypIter_LENHINT(i) = 0;
     ypIter_FUNC(i) = _iter_closed_generator;
 
-    // Handle the returned value from the generator.  yp_StopIteration and yp_GeneratorExit are not
-    // errors.  Any other exception or yielded value _is_ an error, as per Python.
+    // Handle the returned value from the generator. yp_StopIteration and yp_GeneratorExit are not
+    // errors. Any other exception or yielded value _is_ an error, as per Python.
     if (yp_isexceptionCN(result, 2, yp_StopIteration, yp_GeneratorExit)) return yp_None;
     if (yp_isexceptionC(result)) return result;
     yp_decref(result);  // discard unexpectedly-yielded value
@@ -2821,7 +2821,7 @@ static ypObject *iter_send(ypObject *i, ypObject *value)
     ypObject *result = _iter_send(i, value);
 
     // As per Python, when a generator raises an exception, it can't continue to yield values, so
-    // close it.  If iter_close fails just ignore it: result is already set to an exception.
+    // close it. If iter_close fails just ignore it: result is already set to an exception.
     // TODO Don't hide errors from iter_close; instead, use Python's "while handling this
     // exception, another occurred" style of reporting
     if (yp_isexceptionC(result)) {
@@ -2836,7 +2836,7 @@ static ypObject *iter_send(ypObject *i, ypObject *value)
 static ypObject *iter_dealloc(ypObject *i, void *memo)
 {
     // FIXME Is there something better we can do to handle errors than just ignore them?
-    // TODO iter_close calls yp_decref.  Can we get it to call yp_decref_fromdealloc instead?
+    // TODO iter_close calls yp_decref. Can we get it to call yp_decref_fromdealloc instead?
     (void)iter_close(i);  // ignore errors; discards all references
     ypMem_FREE_CONTAINER(i, ypIterObject);
     return yp_None;
@@ -2974,7 +2974,7 @@ void yp_unpackNV(ypObject *iterable, int n, va_list args_orig)
     ypObject  **dest;
 
     // Set the given n arguments to the values yielded from iterable; if an exception occurs, we
-    // will need to restart and discard these values.  Remember that if yp_miniiter fails,
+    // will need to restart and discard these values. Remember that if yp_miniiter fails,
     // yp_miniiter_next will return the same exception.
     // TODO Hmmm; let's say iterable was yp_StopIteration for some reason: this code would actually
     // succeed when n=0 even though it should probably fail...we should check the yp_miniiter
@@ -3440,8 +3440,8 @@ static ypObject *_yp_sametype_deepcopy_visitor(ypObject *x, void *memo)
 
 ypObject *yp_deepcopy(ypObject *x) { return _yp_deepcopy(x, _yp_sametype_deepcopy_visitor); }
 
-// TODO CONTAINER_INLINE objects won't release any of their memory on invalidation.  This is a
-// tradeoff in the interests of reducing individual allocations.  Perhaps there should be a limit
+// TODO CONTAINER_INLINE objects won't release any of their memory on invalidation. This is a
+// tradeoff in the interests of reducing individual allocations. Perhaps there should be a limit
 // on how large to make CONTAINER_INLINE objects, or perhaps we should try to shrink the
 // invalidated object in-place (if supported by the heap).
 // TODO Should attempting to invalidate an immortal be an error?
@@ -3465,16 +3465,16 @@ void yp_deepinvalidate(ypObject **x)
  *************************************************************************************************/
 #pragma region comparison
 
-// Returns 1 if the object is yp_True, else 0.  b must be a bool or an exception.
+// Returns 1 if the object is yp_True, else 0. b must be a bool or an exception.
 #define ypBool_IS_TRUE_C(b) ((b) == yp_True)
 
-// Returns 1 if the object is yp_False, else 0.  b must be a bool or an exception.
+// Returns 1 if the object is yp_False, else 0. b must be a bool or an exception.
 #define ypBool_IS_FALSE_C(b) ((b) == yp_False)
 
 // Returns yp_True if cond is true (non-zero), else yp_False.
 #define ypBool_FROM_C(cond) ((cond) ? yp_True : yp_False)
 
-// yp_not as a macro.  b must be a bool or an exception.
+// yp_not as a macro. b must be a bool or an exception.
 // XXX b should be a variable, _not_ an expression, as it's evaluated up to three times
 // clang-format off
 #define ypBool_NOT(b) ( (b) == yp_True ? yp_False : \
@@ -3807,7 +3807,7 @@ static ypTypeObject ypInvalidated_Type = {
 #pragma region exception
 
 // TODO A nohtyP.h macro to get exception info as a string, include file/line info of the place
-// the macro is checked.  Something to make reporting exceptions easier for the user of nohtyP.
+// the macro is checked. Something to make reporting exceptions easier for the user of nohtyP.
 
 #define _ypException_NAME(e) (((ypExceptionObject *)e)->name)
 #define _ypException_SUPER(e) (((ypExceptionObject *)e)->super)
@@ -4860,9 +4860,9 @@ static yp_int_t _yp_mulL_minint(yp_int_t y, ypObject **exc)
     return_yp_CEXC_ERR(0, exc, yp_OverflowError);
 }
 
-// Special case of yp_mulL where both x and y are positive, or zero.  Returns yp_INT_T_MIN if
+// Special case of yp_mulL where both x and y are positive, or zero. Returns yp_INT_T_MIN if
 // x*y overflows to _exactly_ that value; it will be up to the caller to determine if this is
-// a valid result.  All other overflows will return a negative number strictly larger than
+// a valid result. All other overflows will return a negative number strictly larger than
 // yp_INT_T_MIN.
 // TODO It would be easier just to check "x > max/y"...how does the performance compare, though?
 static yp_int_t _yp_mulL_posints(yp_int_t x, yp_int_t y)
@@ -4924,7 +4924,7 @@ static yp_int_t _yp_mulL_posints(yp_int_t x, yp_int_t y)
     return yp_UINT_MATH(result_hi, +, result_lo);
 }
 
-// Python 2.7's int_mul uses the phrase "close enough", which scares me.  I prefer the method
+// Python 2.7's int_mul uses the phrase "close enough", which scares me. I prefer the method
 // described at http://www.fefe.de/intof.html, although it requires abs(x) and abs(y), meaning
 // we need to handle yp_INT_T_MIN specially because we can't negate it.
 yp_int_t yp_mulL(yp_int_t x, yp_int_t y, ypObject **exc)
@@ -5001,13 +5001,13 @@ void yp_divmodL(yp_int_t x, yp_int_t y, yp_int_t *_div, yp_int_t *_mod, ypObject
      * for an example of overflow, take x = LONG_MIN, y = 5 or x =
      * LONG_MAX, y = -5.)  However, x - xdivy*y is always
      * representable as a long, since it lies strictly between
-     * -abs(y) and abs(y).  We add casts to avoid intermediate
+     * -abs(y) and abs(y). We add casts to avoid intermediate
      * overflow.
      */
     xmody = yp_UINT_MATH(x, -, yp_UINT_MATH(xdivy, *, y));
     /* If the signs of x and y differ, and the remainder is non-0,
      * C89 doesn't define whether xdivy is now the floor or the
-     * ceiling of the infinitely precise quotient.  We want the floor,
+     * ceiling of the infinitely precise quotient. We want the floor,
      * and we have it iff the remainder's sign matches y's.
      */
     if (xmody && ((y ^ xmody) < 0)) {  // i.e. and signs differ
@@ -5053,7 +5053,7 @@ yp_int_t yp_powL3(yp_int_t x, yp_int_t y, yp_int_t z, ypObject **exc)
              * The (unsigned long) cast below ensures that the multiplication
              * is interpreted as an unsigned operation rather than a signed one
              * (C99 6.3.1.8p1), thus avoiding the perils of undefined behaviour
-             * from signed arithmetic overflow (C99 6.5p5).  See issue #12973.
+             * from signed arithmetic overflow (C99 6.5p5). See issue #12973.
              */
             result = yp_UINT_MATH(result, *, temp);
             if (temp == 0) break;  // Avoid result / 0
@@ -5629,8 +5629,8 @@ static yp_int_t yp_index_asintC(ypObject *x, ypObject **exc)
     return_yp_CEXC_BAD_TYPE(0, exc, x);
 }
 
-// Defines the conversion functions.  Overflow checking is done by first truncating the value then
-// seeing if it equals the stored value.  Note that when yp_asintC raises an exception, it returns
+// Defines the conversion functions. Overflow checking is done by first truncating the value then
+// seeing if it equals the stored value. Note that when yp_asintC raises an exception, it returns
 // zero, which can be represented in every integer type, so we won't override any yp_TypeError
 // errors.
 // TODO review http://blog.reverberate.org/2012/12/testing-for-integer-overflow-in-c-and-c.html
@@ -5694,7 +5694,7 @@ static yp_hash_t yp_index_ashashC(ypObject *x, ypObject **exc) { return yp_index
 
 // TODO Make this a public API?
 // Similar to yp_int and yp_asintC, but raises yp_ArithmeticError rather than truncating a float
-// toward zero.  An important property is that yp_int_exact(x) will equal x.
+// toward zero. An important property is that yp_int_exact(x) will equal x.
 // XXX Inspired by Python's Decimal.to_integral_exact; yp_ArithmeticError may be replaced with a
 // more-specific sub-exception in the future
 // FIXME Decimal.to_integral_exact doesn't raise an error: it rounds! Python is tricky as to where
@@ -6148,12 +6148,12 @@ yp_int_t yp_asintLF(yp_float_t x, ypObject **exc)
     yp_float_t wholepart;  // integral portion of x, rounded toward 0
 
     (void)modf(x, &wholepart);
-    /* Try to get out cheap if this fits in a Python int.  The attempt
+    /* Try to get out cheap if this fits in a Python int. The attempt
      * to cast to long must be protected, as C doesn't define what
-     * happens if the double is too big to fit in a long.  Some rare
+     * happens if the double is too big to fit in a long. Some rare
      * systems raise an exception then (RISCOS was mentioned as one,
      * and someone using a non-default option on Sun also bumped into
-     * that).  Note that checking for >= and <= LONG_{MIN,MAX} would
+     * that). Note that checking for >= and <= LONG_{MIN,MAX} would
      * still be vulnerable:  if a long has more bits of precision than
      * a double, casting MIN/MAX to double may yield an approximation,
      * and if that's rounded up, then, e.g., wholepart=LONG_MAX+1 would
@@ -6189,7 +6189,7 @@ static yp_int_t yp_asint_exactLF(yp_float_t x, ypObject **exc)
  *************************************************************************************************/
 #pragma region sequence
 
-// Using the given length, adjusts negative indices to positive.  Returns false if the adjusted
+// Using the given length, adjusts negative indices to positive. Returns false if the adjusted
 // index is out-of-bounds, else true.
 static int ypSequence_AdjustIndexC(yp_ssize_t length, yp_ssize_t *i)
 {
@@ -6226,7 +6226,7 @@ static int ypSequence_AdjustIndexC(yp_ssize_t length, yp_ssize_t *i)
 #endif
 
 // Using the given length, in-place converts the given start/stop/step values to valid indices, and
-// also calculates the length of the slice.  Returns yp_ValueError if *step is zero, else yp_None;
+// also calculates the length of the slice. Returns yp_ValueError if *step is zero, else yp_None;
 // there are no out-of-bounds errors with slices.
 // XXX yp_SLICE_DEFAULT is yp_SSIZE_T_MIN, which hopefully nobody will try to use as a valid index.
 // yp_SLICE_USELEN is yp_SSIZE_T_MAX, which is simply a very large number that is handled the same
@@ -6276,7 +6276,7 @@ static ypObject *ypSlice_AdjustIndicesC(yp_ssize_t length, yp_ssize_t *start, yp
 }
 
 // Using the given _adjusted_ values, in-place converts the given start/stop/step values to the
-// inverse slice, where *step=-(*step).  slicelength must be >0 (slicelength==0 is a no-op).
+// inverse slice, where *step=-(*step). slicelength must be >0 (slicelength==0 is a no-op).
 // XXX Adapted from Python's list_ass_subscript
 // XXX Check for the empty slice case first
 static void ypSlice_InvertIndicesC(
@@ -6297,13 +6297,13 @@ static void ypSlice_InvertIndicesC(
     *step = -(*step);
 }
 
-// Returns the index of the i'th item in the slice with the given adjusted start/step values.  i
+// Returns the index of the i'th item in the slice with the given adjusted start/step values. i
 // must be in range(slicelength).
 #define ypSlice_INDEX(start, step, i) ((start) + (i) * (step))
 
-// Used by tp_repeat et al to perform the necessary memcpy's.  data must be allocated to hold
+// Used by tp_repeat et al to perform the necessary memcpy's. data must be allocated to hold
 // factor*n_size objects, the bytes to repeat must be in the first n_size bytes of data, and the
-// rest of data must not contain any references (they will be overwritten).  Cannot fail.
+// rest of data must not contain any references (they will be overwritten). Cannot fail.
 // XXX Handle the "empty" case (factor<1 or n_size<1) before calling this function
 static void _ypSequence_repeat_memcpy(void *_data, yp_ssize_t factor, yp_ssize_t n_size)
 {
@@ -6319,7 +6319,7 @@ static void _ypSequence_repeat_memcpy(void *_data, yp_ssize_t factor, yp_ssize_t
 }
 
 // Used to remove elements from an array containing length elements, each of elemsize bytes. start,
-// stop, step, and slicelength must be the _adjusted_ values from ypSlice_AdjustIndicesC.  Any
+// stop, step, and slicelength must be the _adjusted_ values from ypSlice_AdjustIndicesC. Any
 // references in the removed elements must have already been discarded.
 // XXX Check for the empty slice and total slice cases first
 static void _ypSlice_delslice_memmove(void *array, yp_ssize_t length, yp_ssize_t elemsize,
@@ -6397,10 +6397,10 @@ static ypObject *_ypSequence_delitem(ypObject *x, ypObject *key)
 typedef struct _yp_codecs_error_handler_params_t {
     yp_ssize_t sizeof_struct;  // Set to yp_sizeof(yp_codecs_error_handler_params_t) on allocation
 
-    // Details of the error.  All references, va_lists, and pointers are borrowed and should not be
+    // Details of the error. All references, va_lists, and pointers are borrowed and should not be
     // replaced.
     // TODO Python's error handlers are flexible enough to take any exception object containing
-    // any data.  Make sure this, while optimized for Unicode, can do the same.
+    // any data. Make sure this, while optimized for Unicode, can do the same.
     ypObject *exc;       // yp_UnicodeEncodeError, *DecodeError, or *TranslateError
     ypObject *encoding;  // The unaliased name of the encoding that raised the error
     struct {             // A to-be-formatted string+args describing the specific codec error
@@ -6424,7 +6424,7 @@ typedef struct _yp_codecs_error_handler_params_t {
     yp_ssize_t end;    // The index after the last invalid data in source
 } yp_codecs_error_handler_params_t;
 
-// Error handler.  Either raise params->exc, or a different error, via *replacement.  Otherwise,
+// Error handler. Either raise params->exc, or a different error, via *replacement. Otherwise,
 // set *replacement to the object that replaces the bad data, and *new_position to the index at
 // which to restart encoding/decoding.
 // XXX It's possible for *new_position to be less than or even greater than params->end on output
@@ -6434,8 +6434,8 @@ typedef void (*yp_codecs_error_handler_func_t)(
 
 // Registers the alias as an alternate name for the encoding and returns the immortal yp_None. Both
 // alias and encoding are normalized before being registered (lowercased, ' ' and '_' converted to
-// '-').  Attempting to register "utf-8" as an alias will raise yp_ValueError; however, there is no
-// other protection against using encoding names as aliases.  Returns an exception on error.
+// '-'). Attempting to register "utf-8" as an alias will raise yp_ValueError; however, there is no
+// other protection against using encoding names as aliases. Returns an exception on error.
 static ypObject *yp_codecs_register_alias(ypObject *alias, ypObject *encoding);
 
 // Returns a new reference to the normalized, unaliased encoding name.
@@ -6443,15 +6443,15 @@ static ypObject *yp_codecs_register_alias(ypObject *alias, ypObject *encoding);
 // we want to be before releasing this API
 static ypObject *yp_codecs_lookup_alias(ypObject *alias);
 
-// Registers error_handler under the given name, and returns the immortal yp_None.  This handler
+// Registers error_handler under the given name, and returns the immortal yp_None. This handler
 // will be called on codec errors when name is specified as the errors parameter (see yp_encode3
-// for an example).  Returns an exception on error.
+// for an example). Returns an exception on error.
 // TODO Make error_handler a function object.
 static ypObject *yp_codecs_register_error(
         ypObject *name, yp_codecs_error_handler_func_t error_handler);
 
-// Returns the error_handler associated with the given name.  Raises yp_LookupError if the handler
-// cannot be found.  Sets *exc and returns the built-in "strict" handler on error (which may not
+// Returns the error_handler associated with the given name. Raises yp_LookupError if the handler
+// cannot be found. Sets *exc and returns the built-in "strict" handler on error (which may not
 // be the _registered_ "strict" handler.)
 // TODO We protect "utf-8" from being aliased; should we protect "strict"/etc?
 static yp_codecs_error_handler_func_t yp_codecs_lookup_errorE(ypObject *name, ypObject **exc);
@@ -6481,9 +6481,9 @@ static yp_codecs_error_handler_func_t yp_codecs_lookup_errorE(ypObject *name, yp
 #define ypStringLib_SET_ALLOCLEN ypObject_SET_ALLOCLEN
 #define ypStringLib_INLINE_DATA(s) (((ypStringLibObject *)s)->ob_inline_data)
 
-// The maximum possible alloclen and length of any string object.  While Latin-1 could technically
+// The maximum possible alloclen and length of any string object. While Latin-1 could technically
 // allow four times as much data as ucs-4, for simplicity we use one maximum length for all
-// encodings.  (Consider that an element in the largest Latin-1 chrarray could be replaced with a
+// encodings. (Consider that an element in the largest Latin-1 chrarray could be replaced with a
 // ucs-4 character, thus quadrupling its size.)
 // XXX On the flip side, this means it's possible to create a string that, when encoded, cannot
 // fit in a bytes object, as it'll be larger than LEN_MAX.
@@ -6550,17 +6550,17 @@ static yp_codecs_error_handler_func_t yp_codecs_lookup_errorE(ypObject *name, yp
                 (ypStringLib_LEN(s) - (src) + 1) << ypStringLib_ENC(s)->sizeshift);                \
     } while (0)
 
-// Gets the ordinal at src[src_i].  src_i must be in range(len): no bounds checking is performed.
+// Gets the ordinal at src[src_i]. src_i must be in range(len): no bounds checking is performed.
 // TODO Is there a declaration we could give this (or the definitions) to make them faster?
 typedef yp_uint32_t (*ypStringLib_getindexXfunc)(const void *src, yp_ssize_t src_i);
 
-// Sets dest[dest_i] to value.  dest_i must be in range(alloclen): no bounds checking is performed.
+// Sets dest[dest_i] to value. dest_i must be in range(alloclen): no bounds checking is performed.
 // XXX dest's encoding must be able to store value
 // TODO Is there a declaration we could give this (or the definitions) to make them faster?
 typedef void (*ypStringLib_setindexXfunc)(void *dest, yp_ssize_t dest_i, yp_uint32_t value);
 
 // XXX In general for this table, make sure you do not use type codes with the wrong
-// ypStringLib_ENC_* value.  ypStringLib_ENC_CODE_BYTES should only be used for bytes, and
+// ypStringLib_ENC_* value. ypStringLib_ENC_CODE_BYTES should only be used for bytes, and
 // vice-versa.
 // XXX max_char may be larger than ypStringLib_MAX_UNICODE
 typedef struct {
@@ -6881,7 +6881,7 @@ yp_STATIC_ASSERT(((_yp_uint_t)ypStringLib_TYPE_CHECKENC_1FROM4_MASK) ==
 yp_STATIC_ASSERT(((_yp_uint_t)ypStringLib_TYPE_CHECKENC_2FROM4_MASK) ==
                          ypStringLib_TYPE_CHECKENC_2FROM4_MASK,
         checkenc_2from4_mask_matches_type);
-// Returns true if the ucs-4 string can be encoded in the encoding matching mask.  *p will point
+// Returns true if the ucs-4 string can be encoded in the encoding matching mask. *p will point
 // to the location that failed the check, or to *end on success.
 // XXX On first look, this shares a lot of code with _ypStringLib_checkenc_contiguous_ucs_2.
 // However, the two "unaligned elements" loops are different (16- vs 32-bit reads).
@@ -7154,7 +7154,7 @@ static ypObject *_ypStr_asitemC(
 
 // Return a new bytes/bytearray/str/chrarray object that can fit the given requiredLen plus the null
 // terminator. If type is immutable and alloclen_fixed is true (indicating the object will never
-// grow), the data is placed inline with one allocation.  enc_code must agree with type.
+// grow), the data is placed inline with one allocation. enc_code must agree with type.
 // XXX Remember to add the null terminator
 // XXX Check for the empty immutable, negative len, and >max len cases first
 // TODO Put protection in place to detect when INLINE objects attempt to be resized
@@ -7216,7 +7216,7 @@ static ypObject *ypStringLib_new_empty(int type)
     }
 }
 
-// Returns a new copy of s of the given type.  If type is immutable and alloclen_fixed is true
+// Returns a new copy of s of the given type. If type is immutable and alloclen_fixed is true
 // (indicating the object will never grow), the data is placed inline with one allocation.
 // XXX Check for the possibility of a lazy shallow copy before calling this function
 // XXX Check for the empty immutable case first
@@ -7273,7 +7273,7 @@ static ypObject *_ypStringLib_maybe_realloc(
         ypStringLib_SET_ALLOCLEN(s, haveBytes >> newEnc->sizeshift);
         return ypStringLib_DATA(s);
     } else {
-        // ypMem_REALLOC sets alloclen, but does not require it to be correct on input.  If it did,
+        // ypMem_REALLOC sets alloclen, but does not require it to be correct on input. If it did,
         // we'd need to adjust it to the new encoding first.
         return ypMem_REALLOC_CONTAINER_VARIABLE5(s, ypStringLibObject, requiredLen + 1, extra,
                 ypStringLib_ALLOCLEN_MAX, newEnc->elemsize);
@@ -7877,7 +7877,7 @@ static ypObject *ypStringLib_find(ypObject *s, void *x_data, yp_ssize_t x_len, y
     yp_uint8_t *s_rdata;   // remaining data
 
     // XXX Unlike Python, the arguments start and end are always treated as in slice notation.
-    // Python behaves peculiarly when end<start in certain edge cases involving empty strings.  See
+    // Python behaves peculiarly when end<start in certain edge cases involving empty strings. See
     // https://bugs.python.org/issue24243.
     result = ypSlice_AdjustIndicesC(ypStringLib_LEN(s), &start, &stop, &step, &s_rlen);
     if (yp_isexceptionC(result)) return result;
@@ -7989,7 +7989,7 @@ static ypObject *_ypStringLib_join_fromstring(ypObject *s, ypObject *x)
 }
 
 // Performs the necessary elemcopy's on behalf of ypStringLib_join, null-terminates, and updates
-// result's length.  Assumes adequate space has already been allocated, and that type checking on
+// result's length. Assumes adequate space has already been allocated, and that type checking on
 // seq's elements has already been performed.
 static void _ypStringLib_join_elemcopy(
         ypObject *result, ypObject *s, const ypQuickSeq_methods *seq, ypQuickSeq_state *state)
@@ -8106,7 +8106,7 @@ static ypObject *ypStringLib_join(
 
 // Calls the error handler with appropriate arguments, sets *newPos to the (adjusted) index at
 // which encoding should continue, and returns the replacement that should be concatenated onto the
-// encoded bytes (using ypStringLib_encode_extend_replacement, perhaps).  Returns exception on
+// encoded bytes (using ypStringLib_encode_extend_replacement, perhaps). Returns exception on
 // error (*newPos will be undefined).
 // XXX Adapted from Python's unicode_encode_call_errorhandler
 static ypObject *ypStringLib_encode_call_errorhandler(yp_codecs_error_handler_func_t errorHandler,
@@ -8151,8 +8151,8 @@ static ypObject *ypStringLib_encode_call_errorhandler(yp_codecs_error_handler_fu
 }
 
 // future_growth is an upper-bound estimate of the number of additional bytes, not including
-// the replacement text, that are expected to be added to encoded.  After appending, encoded will
-// have at least future_growth space available.  Does not null-terminate encoded.
+// the replacement text, that are expected to be added to encoded. After appending, encoded will
+// have at least future_growth space available. Does not null-terminate encoded.
 // TODO Rewrite to use ypStringLib_extend_fromstring? (Although, what about future_growth?)
 static ypObject *ypStringLib_encode_extend_replacement(
         ypObject *encoded, ypObject *replacement, yp_ssize_t future_growth)
@@ -8192,7 +8192,7 @@ static ypObject *ypStringLib_encode_extend_replacement(
 
 // Calls the error handler with appropriate arguments, sets *newPos to the (adjusted) index at
 // which decoding should continue, and returns the replacement that should be concatenated onto the
-// decoded string (using ypStringLib_decode_extend_replacement, perhaps).  Returns exception on
+// decoded string (using ypStringLib_decode_extend_replacement, perhaps). Returns exception on
 // error (*newPos will be undefined).
 // XXX Adapted from Python's unicode_decode_call_errorhandler_writer
 static ypObject *ypStringLib_decode_call_errorhandler(yp_codecs_error_handler_func_t errorHandler,
@@ -8234,8 +8234,8 @@ static ypObject *ypStringLib_decode_call_errorhandler(yp_codecs_error_handler_fu
 }
 
 // future_growth is an upper-bound estimate of the number of additional characters, not including
-// the replacement text, that are expected to be added to decoded.  After appending, decoded will
-// have at least future_growth space available.  Does not null-terminate decoded.
+// the replacement text, that are expected to be added to decoded. After appending, decoded will
+// have at least future_growth space available. Does not null-terminate decoded.
 // TODO Rewrite to use ypStringLib_extend_fromstring? (Although, what about future_growth?)
 static ypObject *ypStringLib_decode_extend_replacement(
         ypObject *decoded, ypObject *replacement, yp_ssize_t future_growth)
@@ -8276,7 +8276,7 @@ static ypObject *ypStringLib_decode_extend_replacement(
 
 // UTF-8 encoding and decoding functions
 
-// Returns the number of consecutive ascii bytes starting at start.  Valid for ascii, latin-1, and
+// Returns the number of consecutive ascii bytes starting at start. Valid for ascii, latin-1, and
 // utf-8 encodings.
 // XXX Adapted from Python's ascii_decode
 #define ypStringLib_ASCII_CHAR_MASK 0x8080808080808080ULL
@@ -8290,14 +8290,14 @@ static yp_ssize_t ypStringLib_count_ascii_bytes(const yp_uint8_t *start, const y
     // If we don't contain an aligned _yp_uint_t, jump to the end
     if (aligned_end - start < yp_sizeof(_yp_uint_t)) goto final_loop;
 
-    // Read the first few bytes until we're aligned.  We can return early because we're reading
+    // Read the first few bytes until we're aligned. We can return early because we're reading
     // byte-by-byte.
     while (!yp_IS_ALIGNED(p, yp_sizeof(_yp_uint_t))) {
         if (((yp_uint8_t)*p) & 0x80) return p - start;
         ++p;
     }
 
-    // Now read as many aligned ints as we can.  Remember that even though the CHAR_MASK test may
+    // Now read as many aligned ints as we can. Remember that even though the CHAR_MASK test may
     // fail, there may still be a few ascii bytes, so we still need to jump to the end.
     while (p < aligned_end) {
         _yp_uint_t value = *((_yp_uint_t *)p);
@@ -8318,7 +8318,7 @@ final_loop:
 #define ypStringLib_UTF_8_IS_CONTINUATION(ch) ((ch) >= 0x80 && (ch) < 0xC0)
 
 // _ypStringLib_decode_utf_8_inner_loop either returns one of these values, or the out-of-range
-// character (>0xFF) that was decoded (but not written to dest).  The "invalid continuation" values
+// character (>0xFF) that was decoded (but not written to dest). The "invalid continuation" values
 // (1, 2, and 3) are chosen so that the value gives the number of bytes that must be skipped.
 // clang-format off
 #define ypStringLib_UTF_8_DATA_END          (0u)    // aka success
@@ -8329,9 +8329,9 @@ final_loop:
 #define ypStringLib_UTF_8_INVALID_END       (5u)    // *unexpected* end of data
 // clang-format on
 
-// Appends the decoded bytes to dest, updating its length.  If a decoding error occurs, *source
+// Appends the decoded bytes to dest, updating its length. If a decoding error occurs, *source
 // will point to the start of the invalid sequence of bytes, and one of the above error codes will
-// be returned.  If a character is decoded that is too large to fit in dest's encoding, *source
+// be returned. If a character is decoded that is too large to fit in dest's encoding, *source
 // will point to the end of the (valid) sequence of bytes, the character will be returned, and
 // it will be up to the caller to reallocate dest *and* append the character.
 // XXX Don't forget to append the valid-but-too-large character to dest!
@@ -8543,7 +8543,7 @@ Return:
 }
 
 // Called when _ypStringLib_decode_utf_8_inner_loop can't fit the decoded character ch in the
-// current encoding.  This will up-convert dest to an encoding that can fit ch, then append ch.
+// current encoding. This will up-convert dest to an encoding that can fit ch, then append ch.
 // dest will have space for requiredLen characters plus the null terminator (make sure this
 // includes room for ch).
 // TODO Rewrite to call ypStringLib_push?
@@ -8580,7 +8580,7 @@ static ypObject *_ypStringLib_decode_utf_8_outer_loop(ypObject *dest, const yp_u
         yp_uint32_t ch = _ypStringLib_decode_utf_8_inner_loop(dest, &source, end);
 
         if (ch == ypStringLib_UTF_8_DATA_END) {
-            // That's it, everything's decoded.  Null-terminate the object and return.
+            // That's it, everything's decoded. Null-terminate the object and return.
             yp_ASSERT(source == end,
                     "_ypStringLib_decode_utf_8_inner_loop didn't end at the end...?");
             // TODO See how much wasted space is left here and if we should release some back to
@@ -8650,7 +8650,7 @@ static ypObject *_ypStringLib_decode_utf_8_outer_loop(ypObject *dest, const yp_u
 }
 
 
-// Called on a null source.  Returns a (null-terminated) string of null characters of the given
+// Called on a null source. Returns a (null-terminated) string of null characters of the given
 // length.
 static ypObject *_ypStringLib_decode_utf_8_onnull(int type, yp_ssize_t len)
 {
@@ -8662,7 +8662,7 @@ static ypObject *_ypStringLib_decode_utf_8_onnull(int type, yp_ssize_t len)
     return newS;
 }
 
-// Called when source starts with at least one ascii character.  Returns the decoded string object.
+// Called when source starts with at least one ascii character. Returns the decoded string object.
 static ypObject *_yp_chrC(int type, yp_int_t i);
 static ypObject *_ypStringLib_decode_utf_8_ascii_start(
         int type, const yp_uint8_t *source, yp_ssize_t len, ypObject *errors)
@@ -8713,12 +8713,12 @@ static ypObject *_ypStringLib_decode_utf_8_ascii_start(
     return dest;
 }
 
-// Should only be called from  _ypStringLib_decode_utf_8.  Using only the inline buffer of dest,
-// decode the first "few" characters in *source.  As in _ypStringLib_decode_utf_8_inner_loop,
+// Should only be called from  _ypStringLib_decode_utf_8. Using only the inline buffer of dest,
+// decode the first "few" characters in *source. As in _ypStringLib_decode_utf_8_inner_loop,
 // returns either an error code, or the character that could not be written to dest's inline
 // buffer; the latter thus indicates what encoding to start with when allocating the separate
-// buffer.  *source will point to either the error location, or the byte after the returned
-// character; dest may be re-encoded in-place.  On input, dest must be empty and latin-1, and
+// buffer. *source will point to either the error location, or the byte after the returned
+// character; dest may be re-encoded in-place. On input, dest must be empty and latin-1, and
 // *source must be larger than dest's inline buffer (otherwise there's no point in the precheck).
 static yp_uint32_t _ypStringLib_decode_utf_8_inline_precheck(
         ypObject *dest, const yp_uint8_t **source)
@@ -8728,8 +8728,8 @@ static yp_uint32_t _ypStringLib_decode_utf_8_inline_precheck(
     // strings "usually" entirely latin-1, or ucs-2, or ucs-4?  Isn't it enough just to check the
     // first, I dunno, 16 characters?  Doing this won't save on allocations, but it *will* save
     // on the memcpy required to move to a separate buffer.
-    // ...But wait, consider an HTML page.  It's going to start with a bunch of ASCII, then
-    // anything ucs-2 or ucs-4 will be in the middle.  What use cases am I optimizing for:
+    // ...But wait, consider an HTML page. It's going to start with a bunch of ASCII, then
+    // anything ucs-2 or ucs-4 will be in the middle. What use cases am I optimizing for:
     // converting a whole document, or small strings one-at-a-time?
     const yp_uint8_t *fake_end = (*source) + dest_maxinline;
     yp_uint32_t       ch;
@@ -8745,7 +8745,7 @@ static yp_uint32_t _ypStringLib_decode_utf_8_inline_precheck(
     }
 
     // To do anything useful, we need room to upconvert, write ch, then write at least one more
-    // character.  If we can't, we bail.
+    // character. If we can't, we bail.
     dest_maxinline = (ypStringLib_ALLOCLEN(dest) / 2) - 1;
     dest_len = ypStringLib_LEN(dest);
     // -1 for ch, then -1 to make sure we can detect at least one more character
@@ -8762,12 +8762,12 @@ static yp_uint32_t _ypStringLib_decode_utf_8_inline_precheck(
     ypStringLib_ENC_CODE(dest) = ypStringLib_ENC_CODE_UCS_2;
     ypStringLib_SET_ALLOCLEN(dest, ypStringLib_ALLOCLEN(dest) / 2);
 
-    // We are at least ucs-2: see if we are actually ucs-4.  Recall that source was modified above.
+    // We are at least ucs-2: see if we are actually ucs-4. Recall that source was modified above.
     fake_end = (*source) + (dest_maxinline - dest_len);
     return _ypStringLib_decode_utf_8_inner_loop(dest, source, fake_end);
 }
 
-// Called by ypStringLib_decode_frombytesC_utf_8 in the general case.  Returns the decoded string
+// Called by ypStringLib_decode_frombytesC_utf_8 in the general case. Returns the decoded string
 // object.
 static ypObject *_ypStringLib_decode_utf_8(
         int type, const yp_uint8_t *source, yp_ssize_t len, ypObject *errors)
@@ -8809,11 +8809,11 @@ static ypObject *_ypStringLib_decode_utf_8(
 
     } else {
         // We've reached the end of what we can decode into the inline buffer, or there was a
-        // decoding error.  Either way, resize and move on to outer_loop.
+        // decoding error. Either way, resize and move on to outer_loop.
         // XXX That's actually a lie: we've reached fake_end, but it's possible we haven't decoded
-        // as many characters as we estimated and there's still room in the inline buffer.  We
+        // as many characters as we estimated and there's still room in the inline buffer. We
         // _could_ keep adjusting fake_end until there's no more room, but I don't think this is
-        // advantageous.  Don't the first few characters usually determine the encoding?
+        // advantageous. Don't the first few characters usually determine the encoding?
         // XXX Can't overflow because we've checked len<=MAX, and len is worst-case num of chars
         dest_requiredLen = ypStringLib_LEN(dest) /*ch isn't a char*/ + (end - source);
         if (dest_requiredLen > ypStringLib_ALLOCLEN(dest) - 1) {
@@ -8836,12 +8836,12 @@ outer_loop:
 }
 
 // Decodes the len bytes of utf-8 at source according to errors, and returns a new string of the
-// given type.  If source is NULL it is considered as having all null bytes; len cannot be
+// given type. If source is NULL it is considered as having all null bytes; len cannot be
 // negative or greater than ypStringLib_LEN_MAX.
 // XXX Allocation-wise, the worst-case through the code would be a completely ucs-4 string, as we'd
 // allocate len characters (len*4 bytes) for the decoding, but would only decode len/4 characters
 // TODO This is TERRIBLE, because if a string has more than a couple ucs-4 characters, it's
-// probably *mostly* ucs-4 characters.  Is there a quick way to scan the _entire_ string?  Or can
+// probably *mostly* ucs-4 characters. Is there a quick way to scan the _entire_ string?  Or can
 // we just trim the excess once we reach the end?
 // XXX Runtime-wise, the worst-case would probably be a string that starts completely Latin-1 (each
 // character is a call to enc->setindexX), followed by a ucs-2 then a ucs-4 character (each
@@ -9029,7 +9029,7 @@ static ypObject *_ypStringLib_encode_utf_8(int type, ypObject *source, ypObject 
             }
 
             // We can now update our expectation of how many more bytes will be added: it's the
-            // number of characters left to encode (remembering i was modified above).  Remember
+            // number of characters left to encode (remembering i was modified above). Remember
             // ypStringLib_encode_extend_replacement needs dest's len set appropriately.
             ypStringLib_SET_LEN(dest, d - dest_data);
             result = ypStringLib_encode_extend_replacement(
@@ -9105,12 +9105,12 @@ static ypStringLib_getindexXfunc _yp_codecs_strenc2getindexX(ypObject *encoding)
     return NULL;
 }
 
-// Set containing the standard encodings like yp_s_utf_8.  Instead of a series of yp_eq calls,
+// Set containing the standard encodings like yp_s_utf_8. Instead of a series of yp_eq calls,
 // yp_set_getintern is used to return one of these objects, which is then compared by identity
-// (i.e. ptr value).  Initialized in _yp_codecs_initialize.
+// (i.e. ptr value). Initialized in _yp_codecs_initialize.
 static ypObject *_yp_codecs_standard = NULL;
 
-// Dict mapping normalized aliases to "official" names.  Initialized in _yp_codecs_initialize.
+// Dict mapping normalized aliases to "official" names. Initialized in _yp_codecs_initialize.
 // TODO Can we statically-allocate this dict?  Perhaps the standard aliases can fit in the
 // inline array, and if it grows past that then we allocate on the heap.
 static ypObject *_yp_codecs_alias2encoding = NULL;
@@ -9221,7 +9221,7 @@ static ypObject *yp_codecs_lookup_alias(ypObject *alias)
 // (this way, utf-8 can return a bytearray as required by yp_bytearray3)
 
 
-// Dict mapping error handler names to their functions.  Initialized in _yp_codecs_initialize.
+// Dict mapping error handler names to their functions. Initialized in _yp_codecs_initialize.
 // TODO Can we statically-allocate this dict?  Perhaps the standard error handlers can fit in the
 // inline array, and if it grows past that then we allocate on the heap.
 static ypObject *_yp_codecs_errors2handler = NULL;
@@ -9362,7 +9362,7 @@ static ypObject *_yp_codecs_surrogatepass_errors_onencode(
         yp_ssize_t badEnd;      // index of end of surrogates to replace from source
         yp_ssize_t badLen = 0;  // number of surrogate characters to replace
 
-        // Count the number of consecutive surrogates.  Stop at the first non-surrogate, or at the
+        // Count the number of consecutive surrogates. Stop at the first non-surrogate, or at the
         // end of the buffer.
         for (i = params->start; i < params->source.data.len; i++) {
             yp_int_t ch = getindexX(params->source.data.ptr, i);
@@ -9418,8 +9418,8 @@ static ypObject *_yp_codecs_surrogatepass_errors_ondecode(
         yp_ssize_t badEnd;      // index of end of surrogates to replace from source
         yp_ssize_t repLen = 0;  // number of surrogate characters (once decoded) to replace
 
-        // Count the number of consecutive surrogates.  Stop at the first non-surrogate, or at the
-        // end of the buffer.  All surrogates are 3 bytes long.
+        // Count the number of consecutive surrogates. Stop at the first non-surrogate, or at the
+        // end of the buffer. All surrogates are 3 bytes long.
         for (i = params->start; params->source.data.len - i >= 3; i += 3) {
             if (!_yp_codecs_UTF8_SURROGATE_PRECHECK(source_data + i)) break;
             ch = _yp_codecs_UTF8_SURROGATE_DECODE(source_data + i);
@@ -9526,13 +9526,13 @@ yp_STATIC_ASSERT(yp_offsetof(ypBytesObject, ob_inline_data) % yp_MAX_ALIGNMENT =
     } while (0)
 
 // Moves the bytes from [src:] to the index dest; this can be used when deleting bytes, or
-// inserting bytes (the new space is uninitialized).  Assumes enough space is allocated for the
-// move.  Recall that memmove handles overlap.  Also adjusts null terminator.
+// inserting bytes (the new space is uninitialized). Assumes enough space is allocated for the
+// move. Recall that memmove handles overlap. Also adjusts null terminator.
 #define ypBytes_ELEMMOVE(b, dest, src) \
     yp_memmove(ypBytes_DATA(b) + (dest), ypBytes_DATA(b) + (src), ypBytes_LEN(b) - (src) + 1);
 
 // When byte arrays are accepted from C, a negative len indicates that strlen(source) should be
-// used as the length.  This function updates *len accordingly.  Returns false if the final value
+// used as the length. This function updates *len accordingly. Returns false if the final value
 // of *len would be larger than ypBytes_LEN_MAX, in which case *len is undefined and
 // yp_MemorySizeOverflowError should probably be returned.
 static int ypBytes_adjust_lenC(const yp_uint8_t *source, yp_ssize_t *len)
@@ -9850,7 +9850,7 @@ static ypObject *bytes_count(
     if (yp_isexceptionC(result)) return result;
 
     // XXX Unlike Python, the arguments start and stop are always treated as in slice notation.
-    // Python behaves peculiarly when stop<start in certain edge cases involving empty strings.  See
+    // Python behaves peculiarly when stop<start in certain edge cases involving empty strings. See
     // https://bugs.python.org/issue24243.
     result = ypSlice_AdjustIndicesC(ypBytes_LEN(b), &start, &stop, &step, &b_rlen);
     if (yp_isexceptionC(result)) return result;
@@ -9909,7 +9909,7 @@ static ypObject *_bytes_tailmatch(
     if (ypObject_TYPE_PAIR_CODE(x) != ypBytes_CODE) return_yp_BAD_TYPE(x);
 
     // XXX Unlike Python, the arguments start and end are always treated as in slice notation.
-    // Python behaves peculiarly when end<start in certain edge cases involving empty strings.  See
+    // Python behaves peculiarly when end<start in certain edge cases involving empty strings. See
     // https://bugs.python.org/issue24243.
     result = ypSlice_AdjustIndicesC(ypBytes_LEN(b), &start, &end, &step, &slice_len);
     if (yp_isexceptionC(result)) return result;
@@ -10060,7 +10060,7 @@ static ypObject *bytes_gt(ypObject *b, ypObject *x)
     return ypBool_FROM_C(_ypBytes_relative_cmp(b, x) > 0);
 }
 
-// Returns true (1) if the two bytes/bytearrays are equal.  Size is a quick way to check equality.
+// Returns true (1) if the two bytes/bytearrays are equal. Size is a quick way to check equality.
 // TODO Would the pre-computed hash be a quick check for inequality before the memcmp?
 static int _ypBytes_are_equal(ypObject *b, ypObject *x)
 {
@@ -10824,7 +10824,7 @@ static ypObject *str_count(
         ypObject *s, ypObject *x, yp_ssize_t start, yp_ssize_t stop, yp_ssize_t *n)
 {
     // XXX Unlike Python, the arguments start and stop are always treated as in slice notation.
-    // Python behaves peculiarly when stop<start in certain edge cases involving empty strings.  See
+    // Python behaves peculiarly when stop<start in certain edge cases involving empty strings. See
     // https://bugs.python.org/issue24243.
     return yp_NotImplementedError;
 }
@@ -10876,7 +10876,7 @@ static ypObject *_str_tailmatch(
     if (ypObject_TYPE_PAIR_CODE(x) != ypStr_CODE) return_yp_BAD_TYPE(x);
 
     // XXX Unlike Python, the arguments start and end are always treated as in slice notation.
-    // Python behaves peculiarly when end<start in certain edge cases involving empty strings.  See
+    // Python behaves peculiarly when end<start in certain edge cases involving empty strings. See
     // https://bugs.python.org/issue24243.
     result = ypSlice_AdjustIndicesC(ypStr_LEN(s), &start, &end, &step, &slice_len);
     if (yp_isexceptionC(result)) return result;
@@ -11046,7 +11046,7 @@ static ypObject *str_gt(ypObject *s, ypObject *x)
     return ypBool_FROM_C(_ypStr_relative_cmp(s, x) > 0);
 }
 
-// Returns true (1) if the two str/chrarrays are equal.  Size is a quick way to check equality.
+// Returns true (1) if the two str/chrarrays are equal. Size is a quick way to check equality.
 // TODO Would the pre-computed hash be a quick check for inequality before the memcmp?
 static int _ypStr_are_equal(ypObject *s, ypObject *x)
 {
@@ -11520,7 +11520,7 @@ ypObject *yp_chrC(yp_int_t i) { return _yp_chrC(ypStr_CODE, i); }
 #pragma region string_methods
 
 // XXX Since it's not likely that anything other than str and bytes will need to implement these
-// methods, they are left out of the type's method table.  This may change in the future.
+// methods, they are left out of the type's method table. This may change in the future.
 // TODO Since "this may change in the future", perhaps we should raise yp_MethodError instead.
 
 static const ypStringLib_encinfo ypStringLib_encs[4] = {
@@ -11778,8 +11778,8 @@ ypObject *yp_splitlines2(ypObject *s, ypObject *keepends)
 #define ypTuple_LEN_MAX ypTuple_ALLOCLEN_MAX
 
 // Moves the elements from [src:] to the index dest; this can be used when deleting items (they
-// must be discarded first), or inserting (the new space is uninitialized).  Assumes enough space
-// is allocated for the move.  Recall that memmove handles overlap.
+// must be discarded first), or inserting (the new space is uninitialized). Assumes enough space
+// is allocated for the move. Recall that memmove handles overlap.
 #define ypTuple_ELEMMOVE(sq, dest, src)                               \
     yp_memmove(ypTuple_ARRAY(sq) + (dest), ypTuple_ARRAY(sq) + (src), \
             (ypTuple_LEN(sq) - (src)) * yp_sizeof(ypObject *));
@@ -11790,7 +11790,7 @@ ypObject *yp_splitlines2(ypObject *s, ypObject *keepends)
         yp_ASSERT(alloclen <= ypTuple_ALLOCLEN_MAX, "alloclen cannot be >max"); \
     } while (0)
 
-// Return a new tuple/list object with the given alloclen.  If type is immutable and
+// Return a new tuple/list object with the given alloclen. If type is immutable and
 // alloclen_fixed is true (indicating the object will never grow), the data is placed inline
 // with one allocation.
 // XXX Check for the yp_tuple_empty and ypTuple_ALLOCLEN_MAX cases first
@@ -11838,9 +11838,9 @@ static ypObject *_ypTuple_new_detached_array(yp_ssize_t alloclen, ypTuple_detach
 }
 
 // Clears sq, placing the array of objects and other metadata in detached so that the array can be
-// reattached with _ypTuple_attach_array.  This is used by sort and other methods that may execute
+// reattached with _ypTuple_attach_array. This is used by sort and other methods that may execute
 // arbitrary code (i.e. yp_lt) while modifying the list, to prevent that arbitrary code from also
-// modifying the list.  Returns an exception on error, in which case sq is not modified and detached
+// modifying the list. Returns an exception on error, in which case sq is not modified and detached
 // is invalid.
 // XXX Handle the "empty list" case before calling this function.
 // TODO Would a flag on the object to prevent mutations work better? We need it for iterating...
@@ -11885,7 +11885,7 @@ static void _ypTuple_free_detached(ypTuple_detached *detached)
 
 // Reverses the effect of _ypTuple_detach_array, reattaching the array to sq and freeing detached.
 // If it is detected that sq was modified since being detached, sq will be cleared before
-// re-attachment, and yp_ValueError will be raised.  (If clearing sq fails, which is very unlikely,
+// re-attachment, and yp_ValueError will be raised. (If clearing sq fails, which is very unlikely,
 // the contents of sq is undefined and a different exception may be raised.) Also works to attach
 // arrays created by _ypTuple_new_detached_array.
 // XXX sq must have been created with ypMem_MALLOC_CONTAINER_VARIABLE (alloclen_fixed=FALSE);
@@ -12015,15 +12015,15 @@ static ypObject *_ypTuple_deepcopy(int type, ypObject *x, visitfunc copy_visitor
     return sq;
 }
 
-// Used by tp_repeat et al to perform the necessary memcpy's.  sq's array must be allocated
+// Used by tp_repeat et al to perform the necessary memcpy's. sq's array must be allocated
 // to hold factor*n objects, the objects to repeat must be in the first n elements of the array,
-// and the rest of the array must not contain any references (they will be overwritten).  Further,
-// factor and n must both be greater than zero.  Cannot fail.
+// and the rest of the array must not contain any references (they will be overwritten). Further,
+// factor and n must both be greater than zero. Cannot fail.
 // XXX Handle the "empty" case (factor<1 or n<1) before calling this function
 #define _ypTuple_repeat_memcpy(sq, factor, n) \
     _ypSequence_repeat_memcpy(ypTuple_ARRAY(sq), (factor), (n)*yp_sizeof(ypObject *))
 
-// Called on push/append, extend, or irepeat to increase the allocated size of the tuple.  Does not
+// Called on push/append, extend, or irepeat to increase the allocated size of the tuple. Does not
 // update ypTuple_LEN.
 // XXX Check for the "same size" case first
 static ypObject *_ypTuple_extend_grow(ypObject *sq, yp_ssize_t required, yp_ssize_t extra)
@@ -12215,8 +12215,8 @@ static ypObject *_ypTuple_concat_fromtuple(ypObject *sq, ypObject *x)
 }
 
 // Called by setslice to discard the items at sq[start:stop] and shift the items at sq[stop:] to
-// start at sq[stop+growBy]; the pointers at sq[start:stop+growBy] will be uninitialized.  sq must
-// have enough space allocated for the move. Updates ypTuple_LEN.  Cannot fail.
+// start at sq[stop+growBy]; the pointers at sq[start:stop+growBy] will be uninitialized. sq must
+// have enough space allocated for the move. Updates ypTuple_LEN. Cannot fail.
 static void _ypTuple_setslice_elemmove(
         ypObject *sq, yp_ssize_t start, yp_ssize_t stop, yp_ssize_t growBy)
 {
@@ -12229,8 +12229,8 @@ static void _ypTuple_setslice_elemmove(
     ypTuple_SET_LEN(sq, ypTuple_LEN(sq) + growBy);
 }
 
-// Called on a setslice of step 1 and positive growBy, or an insert.  Similar to
-// _ypTuple_setslice_elemmove, except sq will grow if it doesn't have enough space allocated.  On
+// Called on a setslice of step 1 and positive growBy, or an insert. Similar to
+// _ypTuple_setslice_elemmove, except sq will grow if it doesn't have enough space allocated. On
 // error, sq is not modified.
 // XXX start and stop must be adjusted values.
 static ypObject *_ypTuple_setslice_grow(
@@ -12616,7 +12616,7 @@ static ypObject *list_irepeat(ypObject *sq, yp_ssize_t factor)
     return yp_None;
 }
 
-// TODO Python's ins1 does an item-by-item copy rather than a memmove.  Contribute an optimization
+// TODO Python's ins1 does an item-by-item copy rather than a memmove. Contribute an optimization
 // back to Python.
 static ypObject *list_insert(ypObject *sq, yp_ssize_t i, ypObject *x)
 {
@@ -12675,7 +12675,7 @@ static ypObject *tuple_frozen_deepcopy(ypObject *sq, visitfunc copy_visitor, voi
 static ypObject *tuple_bool(ypObject *sq) { return ypBool_FROM_C(ypTuple_LEN(sq)); }
 
 // Sets *i to the index in sq and x of the first differing element, or -1 if the elements are equal
-// up to the length of the shortest object.  Returns exception on error.
+// up to the length of the shortest object. Returns exception on error.
 static ypObject *_ypTuple_cmp_first_difference(ypObject *sq, ypObject *x, yp_ssize_t *i)
 {
     yp_ssize_t min_len;
@@ -12711,7 +12711,7 @@ _ypTuple_RELATIVE_CMP_FUNCTION(le, <=);
 _ypTuple_RELATIVE_CMP_FUNCTION(ge, >=);
 _ypTuple_RELATIVE_CMP_FUNCTION(gt, >);
 
-// Returns yp_True if the two tuples/lists are equal.  Size is a quick way to check equality.
+// Returns yp_True if the two tuples/lists are equal. Size is a quick way to check equality.
 // TODO comparison functions can recurse, just like currenthash...fix!
 static ypObject *tuple_eq(ypObject *sq, ypObject *x)
 {
@@ -12722,7 +12722,7 @@ static ypObject *tuple_eq(ypObject *sq, ypObject *x)
     if (ypObject_TYPE_PAIR_CODE(x) != ypTuple_CODE) return yp_ComparisonNotImplemented;
     if (sq_len != ypTuple_LEN(x)) return yp_False;
 
-    // We need to inspect all our items for equality, which could be time-intensive.  It's fairly
+    // We need to inspect all our items for equality, which could be time-intensive. It's fairly
     // obvious that the pre-computed hash, if available, can save us some time when sq!=x.
     if (ypObject_CACHED_HASH(sq) != ypObject_HASH_INVALID &&
             ypObject_CACHED_HASH(x) != ypObject_HASH_INVALID &&
@@ -12730,8 +12730,8 @@ static ypObject *tuple_eq(ypObject *sq, ypObject *x)
         return yp_False;
     }
     // TODO What if we haven't cached this hash yet, but we could?  Calculating the hash now could
-    // speed up future comparisons against these objects.  But!  What if we're a tuple of mutable
-    // objects...we will then attempt to calculate the hash on every comparison, only to fail.  If
+    // speed up future comparisons against these objects. But!  What if we're a tuple of mutable
+    // objects...we will then attempt to calculate the hash on every comparison, only to fail. If
     // we had a flag to differentiate "tuple of mutables" with "not yet computed"...crap, that
     // still wouldn't quite work, because what if we freeze those mutables?
 
@@ -13107,7 +13107,7 @@ static yp_ssize_t ypQuickIter_tuple_length_hint(
 
 static void ypQuickIter_tuple_close(ypQuickIter_state *state)
 {
-    // No-op.  We don't yp_decref because it's a borrowed reference.
+    // No-op. We don't yp_decref because it's a borrowed reference.
 }
 
 static const ypQuickIter_methods ypQuickIter_tuple_methods = {
@@ -13118,8 +13118,8 @@ static const ypQuickIter_methods ypQuickIter_tuple_methods = {
         ypQuickIter_tuple_close                // close
 };
 
-// Initializes state with the given tuple.  Always succeeds.  Use ypQuickIter_tuple_methods as the
-// method table.  tuple is borrowed by state and most not be freed until methods->close is called.
+// Initializes state with the given tuple. Always succeeds. Use ypQuickIter_tuple_methods as the
+// method table. tuple is borrowed by state and most not be freed until methods->close is called.
 static void ypQuickIter_new_fromtuple(ypQuickIter_state *state, ypObject *tuple)
 {
     yp_ASSERT(ypObject_TYPE_PAIR_CODE(tuple) == ypTuple_CODE, "tuple must be a tuple/list");
@@ -13150,7 +13150,7 @@ static yp_ssize_t ypQuickSeq_tuple_len(ypQuickSeq_state *state, ypObject **exc)
 
 static void ypQuickSeq_tuple_close(ypQuickSeq_state *state)
 {
-    // No-op.  We don't yp_decref because it's a borrowed reference.
+    // No-op. We don't yp_decref because it's a borrowed reference.
 }
 
 static const ypQuickSeq_methods ypQuickSeq_tuple_methods = {
@@ -13160,8 +13160,8 @@ static const ypQuickSeq_methods ypQuickSeq_tuple_methods = {
         ypQuickSeq_tuple_close       // close
 };
 
-// Initializes state with the given tuple.  Always succeeds.  Use ypQuickSeq_tuple_methods as the
-// method table.  tuple is borrowed by state and must not be freed until methods->close is called.
+// Initializes state with the given tuple. Always succeeds. Use ypQuickSeq_tuple_methods as the
+// method table. tuple is borrowed by state and must not be freed until methods->close is called.
 static void ypQuickSeq_new_fromtuple(ypQuickSeq_state *state, ypObject *tuple)
 {
     yp_ASSERT(ypObject_TYPE_PAIR_CODE(tuple) == ypTuple_CODE, "tuple must be a tuple/list");
@@ -14796,7 +14796,7 @@ yp_STATIC_ASSERT(ypSet_RESIZE_AT_NMR <= yp_SSIZE_T_MAX / ypSet_ALLOCLEN_MAX,
         ypSet_space_remaining_cant_overflow);
 static yp_ssize_t _ypSet_space_remaining(ypObject *so)
 {
-    /* If fill >= 2/3 size, adjust size.  Normally, this doubles or
+    /* If fill >= 2/3 size, adjust size. Normally, this doubles or
      * quaduples the size, but it's also possible for the dict to shrink
      * (if ma_fill is much larger than se_used, meaning a lot of dict
      * keys have been deleted).
@@ -14865,7 +14865,7 @@ static ypObject *_ypSet_new(int type, yp_ssize_t minused, int alloclen_fixed)
 
 // XXX Check for the "lazy shallow copy" and "yp_frozenset_empty" cases first
 // TODO It's tempting to look into memcpy to copy the tables, although that would mean the copy
-// would be just as dirty as the original.  But if the original isn't "too dirty"...
+// would be just as dirty as the original. But if the original isn't "too dirty"...
 static void _ypSet_movekey_clean(ypObject *so, ypObject *key, yp_hash_t hash, ypSet_KeyEntry **ep);
 static ypObject *_ypSet_copy(int type, ypObject *x, int alloclen_fixed)
 {
@@ -14927,8 +14927,8 @@ static ypObject *_ypSet_deepcopy(int type, ypObject *x, visitfunc copy_visitor, 
     return so;
 }
 
-// Resizes the set to the smallest size that will hold minused values.  If you want to reduce the
-// need for future resizes, call with a larger minused.  Returns yp_None, or an exception on error.
+// Resizes the set to the smallest size that will hold minused values. If you want to reduce the
+// need for future resizes, call with a larger minused. Returns yp_None, or an exception on error.
 // TODO Do we want to split minused into required and extra, like in other areas?
 yp_STATIC_ASSERT(ypSet_ALLOCLEN_MAX <= yp_SSIZE_T_MAX / yp_sizeof(ypSet_KeyEntry),
         ypSet_resize_cant_overflow);
@@ -15032,7 +15032,7 @@ success:
     return yp_None;
 }
 
-// Steals key and adds it to the hash table at the given location.  loc must not currently be in
+// Steals key and adds it to the hash table at the given location. loc must not currently be in
 // use! Ensure the set is large enough (_ypSet_space_remaining) before adding items.
 // XXX Adapted from Python's insertdict in dictobject.c
 static void _ypSet_movekey(ypObject *so, ypSet_KeyEntry *loc, ypObject *key, yp_hash_t hash)
@@ -15045,9 +15045,9 @@ static void _ypSet_movekey(ypObject *so, ypSet_KeyEntry *loc, ypObject *key, yp_
     ypSet_SET_LEN(so, ypSet_LEN(so) + 1);
 }
 
-// Steals key and adds it to the *clean* hash table.  Only use if the key is known to be absent
+// Steals key and adds it to the *clean* hash table. Only use if the key is known to be absent
 // from the table, and the table contains no deleted entries; this is usually known when
-// cleaning/resizing/copying a table.  Sets *loc to the location at which the key was inserted.
+// cleaning/resizing/copying a table. Sets *loc to the location at which the key was inserted.
 // Ensure the set is large enough (_ypSet_space_remaining) before adding items.
 // XXX Adapted from Python's insertdict_clean in dictobject.c
 static void _ypSet_movekey_clean(ypObject *so, ypObject *key, yp_hash_t hash, ypSet_KeyEntry **ep)
@@ -15082,8 +15082,8 @@ static ypObject *_ypSet_removekey(ypObject *so, ypSet_KeyEntry *loc)
     return oldkey;
 }
 
-// Adds the key to the hash table.  *spaceleft should be initialized from  _ypSet_space_remaining;
-// this function then decrements it with each key added, and resets it on every resize.  growhint
+// Adds the key to the hash table. *spaceleft should be initialized from  _ypSet_space_remaining;
+// this function then decrements it with each key added, and resets it on every resize. growhint
 // is the number of additional items, not including key, that are expected to be added to the set.
 // Returns yp_True if so was modified, yp_False if it wasn't due to the key already being in the
 // set, or an exception on error.
@@ -15113,7 +15113,7 @@ static ypObject *_ypSet_push(
     }
 
     // Otherwise, we need to resize the table to add the key; on the bright side, we can use the
-    // fast _ypSet_movekey_clean.  Give mutable objects a bit of room to grow.  If adding growhint
+    // fast _ypSet_movekey_clean. Give mutable objects a bit of room to grow. If adding growhint
     // overflows ypSet_LEN_MAX (or yp_SSIZE_T_MAX), clamp to ypSet_LEN_MAX.
     if (growhint < 0) growhint = 0;
     if (ypSet_LEN(so) > ypSet_LEN_MAX - 1) return yp_MemorySizeOverflowError;
@@ -15127,7 +15127,7 @@ static ypObject *_ypSet_push(
     return yp_True;
 }
 
-// Removes the key from the hash table.  The set is not resized.  Returns the reference to the
+// Removes the key from the hash table. The set is not resized. Returns the reference to the
 // removed key if so was modified, ypSet_dummy if it wasn't due to the key not being in the
 // set, or an exception on error.
 static ypObject *_ypSet_pop(ypObject *so, ypObject *key)
@@ -15235,7 +15235,7 @@ static ypObject *_ypSet_update_fromiter(ypObject *so, ypObject **mi, yp_uint64_t
     return yp_None;
 }
 
-// Adds the keys yielded from iterable to the set.  If the set has enough space to hold all the
+// Adds the keys yielded from iterable to the set. If the set has enough space to hold all the
 // keys, the set is not resized (important, as yp_setN et al pre-allocate the necessary space).
 // Requires that iterable's items are immutable; unavoidable as they are to be added to the set.
 // XXX Check for the so==iterable case _before_ calling this function
@@ -15270,7 +15270,7 @@ static ypObject *_ypSet_intersection_update_fromset(ypObject *so, ypObject *othe
     yp_ASSERT1(ypObject_TYPE_PAIR_CODE(other) == ypFrozenSet_CODE);
     yp_ASSERT1(so != other);
 
-    // Since we're only removing keys from so, it won't be resized, so we can loop over it.  We
+    // Since we're only removing keys from so, it won't be resized, so we can loop over it. We
     // break once so is empty because we aren't expecting any errors from _ypSet_lookkey.
     for (i = 0; keysleft > 0; i++) {
         if (ypSet_LEN(so) < 1) break;
@@ -15299,12 +15299,12 @@ static ypObject *_ypSet_intersection_update_fromiter(
 
     // TODO can we do this without creating a copy or, alternatively, would it be better to
     // implement this as ypSet_intersection?
-    // Unfortunately, we need to create a short-lived copy of so.  It's either that, or convert
+    // Unfortunately, we need to create a short-lived copy of so. It's either that, or convert
     // mi to a set, or come up with a fancy scheme to "mark" items in so to be deleted.
     so_toremove = _ypSet_copy(ypSet_CODE, so, /*alloclen_fixed=*/FALSE);  // new ref
     if (yp_isexceptionC(so_toremove)) return so_toremove;
 
-    // Remove items from so_toremove that are yielded by mi.  so_toremove is then a set
+    // Remove items from so_toremove that are yielded by mi. so_toremove is then a set
     // containing the keys to remove from so.
     result = _ypSet_difference_update_fromiter(so_toremove, mi, mi_state);
     if (!yp_isexceptionC(result)) {
@@ -15665,7 +15665,7 @@ static ypObject *frozenset_eq(ypObject *so, ypObject *x)
     if (ypObject_TYPE_PAIR_CODE(x) != ypFrozenSet_CODE) return yp_ComparisonNotImplemented;
     if (ypSet_LEN(so) != ypSet_LEN(x)) return yp_False;
 
-    // We need to inspect all our items for equality, which could be time-intensive.  It's fairly
+    // We need to inspect all our items for equality, which could be time-intensive. It's fairly
     // obvious that the pre-computed hash, if available, can save us some time when so!=x.
     if (ypObject_CACHED_HASH(so) != ypObject_HASH_INVALID &&
             ypObject_CACHED_HASH(x) != ypObject_HASH_INVALID &&
@@ -15760,10 +15760,10 @@ static ypObject *set_symmetric_difference_update(ypObject *so, ypObject *x)
     }
 }
 
-// XXX We redirect the new-object set methods to the in-place versions.  Among other things, this
+// XXX We redirect the new-object set methods to the in-place versions. Among other things, this
 // helps to avoid duplicating code.
 // TODO ...except we are creating objects that we destroy then create new ones, which can probably
-// be optimized in certain cases, so rethink these four methods.  At the very least, can we avoid
+// be optimized in certain cases, so rethink these four methods. At the very least, can we avoid
 // the yp_freeze?
 static ypObject *frozenset_union(ypObject *so, int n, va_list args)
 {
@@ -16282,8 +16282,8 @@ ypObject *yp_set(ypObject *iterable)
 // original source for documentation on this implementation
 
 // XXX keyset requires care!  It is potentially shared among multiple dicts, so we cannot remove
-// keys or resize it.  It identifies itself as a frozendict, yet we add keys to it, so it is not
-// truly immutable.  As such, it cannot be exposed outside of the set/dict implementations.  On the
+// keys or resize it. It identifies itself as a frozendict, yet we add keys to it, so it is not
+// truly immutable. As such, it cannot be exposed outside of the set/dict implementations. On the
 // plus side, we can allocate it's data inline (via alloclen_fixed).
 
 // ypDictObject and ypDict_LEN are defined above, for use by the set code
@@ -16452,12 +16452,12 @@ static ypObject *_ypDict_resize(ypObject *mp, yp_ssize_t minused)
 }
 
 // Adds a new key with the given hash at the given key_loc, which may require a resize, and sets
-// value appropriately.  *key_loc must point to a currently-unused location in the hash table; it
-// will be updated if a resize occurs.  Otherwise behaves as _ypDict_push.
+// value appropriately. *key_loc must point to a currently-unused location in the hash table; it
+// will be updated if a resize occurs. Otherwise behaves as _ypDict_push.
 // XXX Adapted from PyDict_SetItem
 // TODO The decision to resize currently depends only on _ypSet_space_remaining, but what if the
 // shared keyset contains 5x the keys that we actually use?  That's a large waste in the value
-// table.  Really, we should have a _ypDict_space_remaining.
+// table. Really, we should have a _ypDict_space_remaining.
 static ypObject *_ypDict_push_newkey(ypObject *mp, ypSet_KeyEntry **key_loc, ypObject *key,
         yp_hash_t hash, ypObject *value, yp_ssize_t *spaceleft, yp_ssize_t growhint)
 {
@@ -16477,7 +16477,7 @@ static ypObject *_ypDict_push_newkey(ypObject *mp, ypSet_KeyEntry **key_loc, ypO
     }
 
     // Otherwise, we need to resize the table to add the key; on the bright side, we can use the
-    // fast _ypSet_movekey_clean.  Give mutable objects a bit of room to grow.  If adding growhint
+    // fast _ypSet_movekey_clean. Give mutable objects a bit of room to grow. If adding growhint
     // overflows ypSet_LEN_MAX (or yp_SSIZE_T_MAX), clamp to ypSet_LEN_MAX.
     if (growhint < 0) growhint = 0;
     if (ypDict_LEN(mp) > ypSet_LEN_MAX - 1) return yp_MemorySizeOverflowError;
@@ -16494,10 +16494,10 @@ static ypObject *_ypDict_push_newkey(ypObject *mp, ypSet_KeyEntry **key_loc, ypO
     return yp_True;
 }
 
-// Adds the key/value to the dict.  If override is false, returns yp_False and does not modify the
-// dict if there is an existing value.  *spaceleft should be initialized from
+// Adds the key/value to the dict. If override is false, returns yp_False and does not modify the
+// dict if there is an existing value. *spaceleft should be initialized from
 // _ypSet_space_remaining; this function then decrements it with each key added, and resets it on
-// every resize.  Returns yp_True if mp was modified, yp_False if it wasn't due to existing values
+// every resize. Returns yp_True if mp was modified, yp_False if it wasn't due to existing values
 // being preserved (ie override is false), or an exception on error.
 // XXX Adapted from PyDict_SetItem
 static ypObject *_ypDict_push(ypObject *mp, ypObject *key, ypObject *value, int override,
@@ -16537,8 +16537,8 @@ static ypObject *_ypDict_push(ypObject *mp, ypObject *key, ypObject *value, int 
     return _ypDict_push_newkey(mp, &key_loc, key, hash, value, spaceleft, growhint);
 }
 
-// Removes the value from the dict; the key stays in the keyset, but that's of no concern.  The
-// dict is not resized.  Returns the reference to the removed value if mp was modified, ypSet_dummy
+// Removes the value from the dict; the key stays in the keyset, but that's of no concern. The
+// dict is not resized. Returns the reference to the removed value if mp was modified, ypSet_dummy
 // if it wasn't due to the value not being set, or an exception on error.
 static ypObject *_ypDict_pop(ypObject *mp, ypObject *key)
 {
@@ -16570,8 +16570,8 @@ static ypObject *_ypDict_pop(ypObject *mp, ypObject *key)
     return oldvalue;  // new ref
 }
 
-// Item iterators yield iterators that yield exactly 2 values: key first, then value.  This
-// returns new references to that pair in *key and *value.  Both are set to an exception on error;
+// Item iterators yield iterators that yield exactly 2 values: key first, then value. This
+// returns new references to that pair in *key and *value. Both are set to an exception on error;
 // in particular, yp_ValueError is returned if exactly 2 values are not returned.
 // XXX Yes, the yielded value can be any iterable, even a set or dict (good luck guessing which
 // will be the key, and which the value)
@@ -16637,7 +16637,7 @@ static ypObject *_ypDict_update_fromiter(ypObject *mp, ypObject **itemiter)
     return yp_None;
 }
 
-// Adds the key/value pairs yielded from either yp_iter_items or yp_iter to the dict.  If the dict
+// Adds the key/value pairs yielded from either yp_iter_items or yp_iter to the dict. If the dict
 // has enough space to hold all the items, the dict is not resized (important, as yp_dictK et al
 // pre-allocate the necessary space).
 // XXX Check for the "fellow frozendict" case before calling this function.
@@ -16731,7 +16731,7 @@ static ypObject *frozendict_eq(ypObject *mp, ypObject *x)
     if (ypObject_TYPE_PAIR_CODE(x) != ypFrozenDict_CODE) return yp_ComparisonNotImplemented;
     if (ypDict_LEN(mp) != ypDict_LEN(x)) return yp_False;
 
-    // We need to inspect all our items for equality, which could be time-intensive.  It's fairly
+    // We need to inspect all our items for equality, which could be time-intensive. It's fairly
     // obvious that the pre-computed hash, if available, can save us some time when mp!=x.
     if (ypObject_CACHED_HASH(mp) != ypObject_HASH_INVALID &&
             ypObject_CACHED_HASH(x) != ypObject_HASH_INVALID &&
@@ -16767,7 +16767,7 @@ static ypObject *frozendict_ne(ypObject *mp, ypObject *x)
 }
 
 // TODO frozendict_currenthash, when implemented, will need to consider the currenthashes of its
-// values as well as its keys.  Just as a tuple with mutable items can't be hashed, hashing a
+// values as well as its keys. Just as a tuple with mutable items can't be hashed, hashing a
 // frozendict with mutable values will be an error.
 //  What about this for the hash?  hash(frozenset(x.items()))  (performance?)
 // Rejected ideas:
@@ -17744,7 +17744,7 @@ static ypObject *range_ne(ypObject *r, ypObject *x)
     return ypBool_NOT(result);
 }
 
-/* Hash function for range objects.  Rough C equivalent of
+/* Hash function for range objects. Rough C equivalent of
    if not len(r):
        return hash((len(r), 0, 1))
    if len(r) == 1:
@@ -19671,7 +19671,7 @@ ypObject *yp_o2s_getitemCX(ypObject *container, ypObject *key, const yp_uint8_t 
     int       container_pair = ypObject_TYPE_PAIR_CODE(container);
 
     // XXX The pointer returned via *encoded is only valid so long as the str/chrarray object
-    // remains allocated and isn't modified.  As such, limit this function to those containers that
+    // remains allocated and isn't modified. As such, limit this function to those containers that
     // we *know* will keep the object allocated (so long as _they_ aren't modified, of course).
     if (container_pair != ypTuple_CODE && container_pair != ypFrozenDict_CODE) {
         return_yp_BAD_TYPE(container);
@@ -19907,7 +19907,7 @@ static ypTypeObject *ypTypeTable[255] = {
 };
 // clang-format on
 
-// TODO Reconsider the behaviour of exceptions.  Python returns `type`.  If we ever want to support
+// TODO Reconsider the behaviour of exceptions. Python returns `type`. If we ever want to support
 // creating instances of exceptions, we should do the same.
 ypObject *yp_type(ypObject *object) { return (ypObject *)ypObject_TYPE(object); }
 
@@ -19976,7 +19976,7 @@ static const yp_initialize_parameters_t _default_initialize = {
     )
 // clang-format on
 
-// Called *exactly* *once* by yp_initialize to set up memory management.  Further, setting
+// Called *exactly* *once* by yp_initialize to set up memory management. Further, setting
 // yp_malloc here helps ensure that yp_initialize is called before anything else in the library
 // (because otherwise all mallocs result in yp_MemoryError).
 static void _ypMem_initialize(const yp_initialize_parameters_t *args)
@@ -19993,20 +19993,20 @@ static void _ypMem_initialize(const yp_initialize_parameters_t *args)
     }
 
     // TODO Config param idea: "minimum" or "average" or "usual" or "preferred" allocation
-    // size...something that indicates that malloc handles these sizes particularly well.  The
-    // number should be small, like 64 bytes or something.  This number can be used to decide how
-    // much data to put in-line.  The call to malloc would use exactly this size when creating an
-    // object, and at least this size when allocating extra data.  This makes all objects the same
-    // size, which will help malloc avoid fragmentation.  It also recognizes the fact that each
+    // size...something that indicates that malloc handles these sizes particularly well. The
+    // number should be small, like 64 bytes or something. This number can be used to decide how
+    // much data to put in-line. The call to malloc would use exactly this size when creating an
+    // object, and at least this size when allocating extra data. This makes all objects the same
+    // size, which will help malloc avoid fragmentation. It also recognizes the fact that each
     // malloc has a certain overhead in memory, so might as well allocate a certain amount to
-    // compensate.  When invalidating an object, the extra data is freed, but the invalidated
+    // compensate. When invalidating an object, the extra data is freed, but the invalidated
     // object that remains would sit in memory with this size until fully freed, so the extra data
-    // is wasted until then, which is why the value should be small.  (Actually, not all objects
+    // is wasted until then, which is why the value should be small. (Actually, not all objects
     // will be this size, as int/float, when they become small objects, will only allocate a
     // fraction of this.)
 }
 
-// Called *exactly* *once* by yp_initialize to set up the codecs module.  Errors are largely
+// Called *exactly* *once* by yp_initialize to set up the codecs module. Errors are largely
 // ignored: calling code will fail gracefully later on.
 // TODO Instead, fail with an ASSERT on any exceptions
 static void _yp_codecs_initialize(const yp_initialize_parameters_t *args)

--- a/nohtyP.h
+++ b/nohtyP.h
@@ -1664,8 +1664,8 @@ ypAPI yp_int_t yp_o2i_getitemC(ypObject *container, ypObject *key, ypObject **ex
 ypAPI void     yp_o2i_setitemC(ypObject *container, ypObject *key, yp_int_t x, ypObject **exc);
 
 // Operations on containers that map objects to strs. yp_o2s_getitemCX is documented below.
-ypAPI void yp_o2s_setitemC4(
-        ypObject **container, ypObject *key, const yp_uint8_t *x, yp_ssize_t x_len);
+ypAPI void yp_o2s_setitemC5(
+        ypObject *container, ypObject *key, const yp_uint8_t *x, yp_ssize_t x_len, ypObject **exc);
 
 // Operations on containers that map integers to objects. Note that if the container is known at
 // compile-time to be a sequence, then yp_getindexC et al are better choices.
@@ -1677,8 +1677,8 @@ ypAPI yp_int_t yp_i2i_getitemC(ypObject *container, yp_int_t key, ypObject **exc
 ypAPI void     yp_i2i_setitemC(ypObject *container, yp_int_t key, yp_int_t x, ypObject **exc);
 
 // Operations on containers that map integers to strs. yp_i2s_getitemCX is documented below.
-ypAPI void yp_i2s_setitemC4(
-        ypObject **container, yp_int_t key, const yp_uint8_t *x, yp_ssize_t x_len);
+ypAPI void yp_i2s_setitemC5(
+        ypObject *container, yp_int_t key, const yp_uint8_t *x, yp_ssize_t x_len, ypObject **exc);
 
 // Operations on containers that map strs to objects. Note that if the value of the str is known at
 // compile-time, as in:
@@ -1690,14 +1690,14 @@ ypAPI void yp_i2s_setitemC4(
 //      yp_IMMORTAL_STR_LATIN_1(s_mykey, "mykey");
 //      value = yp_getitem(o, s_mykey);
 ypAPI ypObject *yp_s2o_getitemC3(ypObject *container, const yp_uint8_t *key, yp_ssize_t key_len);
-ypAPI void      yp_s2o_setitemC4(
-             ypObject **container, const yp_uint8_t *key, yp_ssize_t key_len, ypObject *x);
+ypAPI void      yp_s2o_setitemC5(ypObject *container, const yp_uint8_t *key, yp_ssize_t key_len,
+             ypObject *x, ypObject **exc);
 
 // Operations on containers that map strs to integers.
 ypAPI yp_int_t yp_s2i_getitemC4(
         ypObject *container, const yp_uint8_t *key, yp_ssize_t key_len, ypObject **exc);
-ypAPI void yp_s2i_setitemC4(
-        ypObject **container, const yp_uint8_t *key, yp_ssize_t key_len, yp_int_t x);
+ypAPI void yp_s2i_setitemC5(
+        ypObject *container, const yp_uint8_t *key, yp_ssize_t key_len, yp_int_t x, ypObject **exc);
 
 
 /*

--- a/nohtyP.h
+++ b/nohtyP.h
@@ -1196,7 +1196,7 @@ typedef struct _yp_parameter_decl_t {
     // The name of the parameter as a str. name must be a valid Python identifier, or one of the
     // following special forms.
     //
-    // If name is /, the preceeding parameters are positional-only. / cannot be the first parameter.
+    // If name is /, the preceding parameters are positional-only. / cannot be the first parameter.
     // If / is in the middle, the corresponding argarray element will be NULL. If / is last, it is
     // not included in argarray, and n will be one less than the number of parameters. / cannot come
     // after *, *args, or **kwargs.
@@ -1595,7 +1595,7 @@ typedef struct _yp_state_decl_t {
 //      yp_uint64_t mi_state;
 //      ypObject *mi = yp_miniiter(list, &mi_state);
 //      while(1) {
-//          ypObject *item = yp_miniiter_next(&mi, &mi_state);
+//          ypObject *item = yp_miniiter_next(mi, &mi_state);
 //          if(yp_isexceptionC2(item, yp_StopIteration)) break;
 //          // ... operate on item ...
 //          yp_decref(item);

--- a/nohtyP.h
+++ b/nohtyP.h
@@ -108,8 +108,8 @@ typedef struct _yp_state_decl_t            yp_state_decl_t;
  */
 
 // Must be called once before any other function; subsequent calls are a no-op. If a fatal error
-// occurs abort() is called. args can be NULL to accept all defaults; further documentation
-// on these parameters can be found below.
+// occurs abort() is called. args can be NULL to accept all defaults; further documentation on these
+// parameters can be found below.
 ypAPI void yp_initialize(const yp_initialize_parameters_t *args);
 
 
@@ -135,8 +135,8 @@ ypAPI ypObject *yp_incref(ypObject *x);
 ypAPI void yp_increfN(int n, ...);
 ypAPI void yp_increfNV(int n, va_list args);
 
-// Decrements the reference count of x, deallocating it if the count reaches zero. Always
-// succeeds; if x is immortal this is a no-op.
+// Decrements the reference count of x, deallocating it if the count reaches zero. Always succeeds;
+// if x is immortal this is a no-op.
 ypAPI void yp_decref(ypObject *x);
 
 // A convenience function to decrement the references of n objects.
@@ -194,16 +194,16 @@ typedef yp_float64_t yp_float_t;
  */
 
 // Unlike Python, most nohtyP types have both mutable and immutable versions. An "intstore" is a
-// mutable int (it "stores" an int); similar for floatstore. The mutable str is called a
-// "chrarray", while a "frozendict" is an immutable dict.
+// mutable int (it "stores" an int); similar for floatstore. The mutable str is called a "chrarray",
+// while a "frozendict" is an immutable dict.
 
 // Returns a new reference to an int/intstore with the given value.
 ypAPI ypObject *yp_intC(yp_int_t value);
 ypAPI ypObject *yp_intstoreC(yp_int_t value);
 
 // Returns a new reference to an int/intstore with the given str, chrarray, bytes, or bytearray
-// object interpreted as an integer literal in radix base. The Python-equivalent default for base
-// is 10; a base of 0 means to interpret exactly as a Python code literal.
+// object interpreted as an integer literal in radix base. The Python-equivalent default for base is
+// 10; a base of 0 means to interpret exactly as a Python code literal.
 ypAPI ypObject *yp_int_baseC(ypObject *x, yp_int_t base);
 ypAPI ypObject *yp_intstore_baseC(ypObject *x, yp_int_t base);
 
@@ -219,8 +219,8 @@ ypAPI ypObject *yp_floatstoreCF(yp_float_t value);
 
 // Returns a new reference to a float/floatstore. If x is a number, it is converted to a float.
 // Otherwise, x must be a str, chrarray, bytes, or bytearray object, which will be interpreted as a
-// Python floating-point literal. In either case, if the resulting value is outside the range of
-// a float then yp_OverflowError is returned.
+// Python floating-point literal. In either case, if the resulting value is outside the range of a
+// float then yp_OverflowError is returned.
 ypAPI ypObject *yp_float(ypObject *x);
 ypAPI ypObject *yp_floatstore(ypObject *x);
 
@@ -237,13 +237,15 @@ ypAPI ypObject *yp_iter2(ypObject *callable, ypObject *sentinel);
 // documentation for yp_generator_decl_t for more details.
 ypAPI ypObject *yp_generatorC(yp_generator_decl_t *declaration);
 
-// Returns a new reference to a range object. yp_rangeC is equivalent to yp_rangeC3(0, stop, 1).
+// Returns a new reference to a range object.
 ypAPI ypObject *yp_rangeC3(yp_int_t start, yp_int_t stop, yp_int_t step);
+
+// Equivalent to yp_rangeC3(0, stop, 1).
 ypAPI ypObject *yp_rangeC(yp_int_t stop);
 
-// Returns a new reference to a bytes/bytearray, copying the first len bytes from source. If
-// source is NULL it is considered as having all null bytes; if len is negative source is
-// considered null terminated (and, therefore, will not contain the null byte).
+// Returns a new reference to a bytes/bytearray, copying the first len bytes from source. If source
+// is NULL it is considered as having all null bytes; if len is negative source is considered null
+// terminated (and, therefore, will not contain the null byte).
 //
 // Ex: pre-allocate a bytearray of length 50: yp_bytearrayC(NULL, 50)
 ypAPI ypObject *yp_bytesC(const yp_uint8_t *source, yp_ssize_t len);
@@ -288,8 +290,8 @@ ypAPI ypObject *yp_chrarray_frombytesC2(const yp_uint8_t *source, yp_ssize_t len
 ypAPI ypObject *yp_str3(ypObject *source, ypObject *encoding, ypObject *errors);
 ypAPI ypObject *yp_chrarray3(ypObject *source, ypObject *encoding, ypObject *errors);
 
-// Returns a new reference to the "informal" or nicely-printable string representation of object,
-// as a str/chrarray. As in Python, passing a bytes object to this constructor returns the string
+// Returns a new reference to the "informal" or nicely-printable string representation of object, as
+// a str/chrarray. As in Python, passing a bytes object to this constructor returns the string
 // representation ("b'Zoot!'"); to decode the bytes, use yp_str3.
 ypAPI ypObject *yp_str(ypObject *object);
 ypAPI ypObject *yp_chrarray(ypObject *object);
@@ -308,8 +310,7 @@ ypAPI ypObject *yp_listN(int n, ...);
 ypAPI ypObject *yp_listNV(int n, va_list args);
 
 // Returns a new reference to a tuple/list made from factor shallow-copies of yp_tupleN(n, ...)
-// concatenated; the length will be factor*n. Equivalent to "factor * (obj0, obj1, ...)" in
-// Python.
+// concatenated; the length will be factor*n. Equivalent to "factor * (obj0, obj1, ...)" in Python.
 //
 // Ex: pre-allocate a list of length 99: yp_list_repeatCN(99, 1, yp_None)
 //
@@ -433,8 +434,8 @@ ypAPI ypObject *yp_andNV(int n, va_list args);
 ypAPI ypObject *yp_allN(int n, ...);
 ypAPI ypObject *yp_allNV(int n, va_list args);
 
-// Returns the immortal yp_True if all elements of iterable are true or the iterable is empty.
-// Stops iterating at the first false element.
+// Returns the immortal yp_True if all elements of iterable are true or the iterable is empty. Stops
+// iterating at the first false element.
 ypAPI ypObject *yp_all(ypObject *iterable);
 
 // Implements the "less than" (x<y), "less than or equal" (x<=y), "equal" (x==y), "not equal"
@@ -454,13 +455,13 @@ ypAPI ypObject *yp_gt(ypObject *x, ypObject *y);
  * Generic Object Operations
  */
 
-// Returns the hash value of x; x must be immutable and must not contain mutable objects. Returns
-// -1 and sets *exc on error.
+// Returns the hash value of x; x must be immutable and must not contain mutable objects. Returns -1
+// and sets *exc on error.
 ypAPI yp_hash_t yp_hashC(ypObject *x, ypObject **exc);
 
 // Returns the _current_ hash value of x; this value may change between calls. Returns -1 and sets
-// *exc on error. This is able to calculate the hash value of mutable objects and objects
-// containing mutable objects that would otherwise fail with yp_hashC.
+// *exc on error. This is able to calculate the hash value of mutable objects and objects containing
+// mutable objects that would otherwise fail with yp_hashC.
 ypAPI yp_hash_t yp_currenthashC(ypObject *x, ypObject **exc);
 
 
@@ -491,18 +492,17 @@ ypAPI ypObject *yp_next2(ypObject *iterator, ypObject *defval);
 // yp_StopIteration is raised.
 ypAPI ypObject *yp_throw(ypObject *iterator, ypObject *exception);
 
-// Returns a hint as to how many items are left to be yielded. The accuracy of this hint depends
-// on the underlying type: most containers know their lengths exactly, but some generators may not.
-// A hint of zero could mean that the iterator is exhausted, that the length is unknown, or that
-// the iterator will yield infinite values. Returns zero and sets *exc on error.
+// Returns a hint as to how many items are left to be yielded. The accuracy of this hint depends on
+// the underlying type: most containers know their lengths exactly, but some generators may not. A
+// hint of zero could mean that the iterator is exhausted, that the length is unknown, or that the
+// iterator will yield infinite values. Returns zero and sets *exc on error.
 ypAPI yp_ssize_t yp_length_hintC(ypObject *iterator, ypObject **exc);
 
-// "Closes" the iterator by calling yp_throw(iterator, yp_GeneratorExit). If yp_StopIteration or
-// yp_GeneratorExit is returned by yp_throw, ??FIXME??; on any other error, an exception is
-// returned. The behaviour of this method for other types, in particular files, is documented
-// elsewhere.
-// FIXME what if yp_throw doesn't return an exception?
-ypAPI ypObject *yp_close(ypObject *iterator);
+// "Closes" the iterator by calling yp_throw(iterator, yp_GeneratorExit). yp_throw is expected to
+// return either yp_StopIteration or yp_GeneratorExit: these are not treated as errors. If yp_throw
+// yields a value, it is discarded and yp_RuntimeError is raised. Sets *exc on error. The behaviour
+// of this method for other types, in particular files, is documented elsewhere.
+ypAPI void yp_close(ypObject *iterator, ypObject **exc);
 
 // Sets the given n ypObject**s to new references for the values yielded from iterable. Iterable
 // must yield exactly n objects, or else a yp_ValueError is raised. Sets all n ypObject**s to the
@@ -519,7 +519,7 @@ ypAPI ypObject *yp_filterfalse(ypObject *function, ypObject *iterable);
 
 // Returns a new reference to the largest/smallest of the given n objects. key is a one-argument
 // function used to extract a comparison key from each element in iterable; to compare the elements
-// directly, use yp_None.
+// directly, use yp_None. Note that key is before n as you cannot have arguments after ellipsis.
 ypAPI ypObject *yp_max_keyN(ypObject *key, int n, ...);
 ypAPI ypObject *yp_max_keyNV(ypObject *key, int n, va_list args);
 ypAPI ypObject *yp_min_keyN(ypObject *key, int n, ...);
@@ -587,12 +587,11 @@ ypAPI ypObject *yp_not_in(ypObject *x, ypObject *container);
 // Returns the length of container. Returns zero and sets *exc on error.
 ypAPI yp_ssize_t yp_lenC(ypObject *container, ypObject **exc);
 
-// Adds an item to container. On error, *exc is set to an exception. The relation between yp_push
-// and yp_pop depends on the type: x may be the first or last item popped, or items may be popped in
-// arbitrary order.
+// Adds an item to container. Sets *exc on error. The relation between yp_push and yp_pop depends on
+// the type: x may be the first or last item popped, or items may be popped in arbitrary order.
 ypAPI void yp_push(ypObject *container, ypObject *x, ypObject **exc);
 
-// Removes all items from container. On error, *exc is set to an exception.
+// Removes all items from container. Sets *exc on error.
 ypAPI void yp_clear(ypObject *container, ypObject **exc);
 
 // Removes an item from container and returns a new reference to the item. Not supported on dicts;
@@ -604,15 +603,15 @@ ypAPI ypObject *yp_pop(ypObject *container);
  * Sequence Operations
  */
 
-// These methods are supported by bytes, str, and tuple (and their mutable counterparts, of
-// course). Most methods are also supported by range; notable exceptions are yp_concat and
-// yp_repeatC. They are _not_ supported by frozenset and frozendict because those types do not
-// store their elements in any particular order.
+// These methods are supported by bytes, str, and tuple (and their mutable counterparts, of course).
+// Most methods are also supported by range; notable exceptions are yp_concat and yp_repeatC. They
+// are _not_ supported by frozenset and frozendict because those types do not store their elements
+// in any particular order.
 
 // Sequences are indexed origin zero. Negative indices are relative to the end of the sequence: in
 // effect, when i is negative it is substituted with len(s)+i, and len(s)+j for negative j. The
-// slice of s from i to j with step k is the sequence of items with indices i, i+k, i+2*k, i+3*k
-// and so on, stopping when j is reached (but never including j); k cannot be zero. A single index
+// slice of s from i to j with step k is the sequence of items with indices i, i+k, i+2*k, i+3*k and
+// so on, stopping when j is reached (but never including j); k cannot be zero. A single index
 // outside of range(-len(s),len(s)) raises a yp_IndexError, but in a slice such an index gets
 // clamped to the bounds of the sequence. See yp_SLICE_DEFAULT and yp_SLICE_USELEN below for more
 // information.
@@ -637,71 +636,70 @@ ypAPI ypObject *yp_getitem(ypObject *sequence, ypObject *key);
 // sequence[i:j], or -1 if x is not found. Returns -1 and sets *exc on error; *exc is _not_ set if x
 // is not found. Types such as tuples inspect only one item at a time, while types such as strs look
 // for a particular sub-sequence of items.
-ypAPI yp_ssize_t yp_findC4(
+ypAPI yp_ssize_t yp_findC5(
         ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j, ypObject **exc);
 
-// Equivalent to yp_findC4(sequence, x, 0, yp_SLICE_USELEN, exc).
+// Equivalent to yp_findC5(sequence, x, 0, yp_SLICE_USELEN, exc).
 ypAPI yp_ssize_t yp_findC(ypObject *sequence, ypObject *x, ypObject **exc);
 
-// Similar to yp_findC4 and yp_findC, except sets *exc to yp_ValueError if x is not found.
-ypAPI yp_ssize_t yp_indexC4(
+// Similar to yp_findC5 and yp_findC, except raises yp_ValueError if x is not found.
+ypAPI yp_ssize_t yp_indexC5(
         ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j, ypObject **exc);
 ypAPI yp_ssize_t yp_indexC(ypObject *sequence, ypObject *x, ypObject **exc);
 
-// Similar to yp_findC4, yp_indexC4, etc, except returns the _highest_ index (it starts
-// searching "from the right" or "in reverse".)
-ypAPI yp_ssize_t yp_rfindC4(
+// Similar to yp_findC5, yp_indexC5, etc, except returns the _highest_ index (it starts searching
+// "from the right" or "in reverse".)
+ypAPI yp_ssize_t yp_rfindC5(
         ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j, ypObject **exc);
 ypAPI yp_ssize_t yp_rfindC(ypObject *sequence, ypObject *x, ypObject **exc);
-ypAPI yp_ssize_t yp_rindexC4(
+ypAPI yp_ssize_t yp_rindexC5(
         ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j, ypObject **exc);
 ypAPI yp_ssize_t yp_rindexC(ypObject *sequence, ypObject *x, ypObject **exc);
 
-// Returns the total number of non-overlapping occurrences of x in sequence[i:j]. Returns 0 and
-// sets *exc on error. Types such as tuples inspect only one item at a time, while types such as
-// strs look for a particular sub-sequence of items.
-ypAPI yp_ssize_t yp_countC4(
+// Returns the total number of non-overlapping occurrences of x in sequence[i:j]. Returns 0 and sets
+// *exc on error. Types such as tuples inspect only one item at a time, while types such as strs
+// look for a particular sub-sequence of items.
+ypAPI yp_ssize_t yp_countC5(
         ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j, ypObject **exc);
 
-// Equivalent to yp_countC4(sequence, x, 0, yp_SLICE_USELEN, exc).
+// Equivalent to yp_countC5(sequence, x, 0, yp_SLICE_USELEN, exc).
 ypAPI yp_ssize_t yp_countC(ypObject *sequence, ypObject *x, ypObject **exc);
 
-// Sets the i-th item of sequence to x. On error, *exc is set to an exception.
+// Sets the i-th item of sequence to x. Sets *exc on error.
 ypAPI void yp_setindexC(ypObject *sequence, yp_ssize_t i, ypObject *x, ypObject **exc);
 
 // Sets the slice of sequence, from i to j with step k, to x. The Python-equivalent "defaults" for i
-// and j are yp_SLICE_DEFAULT, while for k it is 1. On error, *exc is set to an exception.
-ypAPI void yp_setsliceC5(
+// and j are yp_SLICE_DEFAULT, while for k it is 1. Sets *exc on error.
+ypAPI void yp_setsliceC6(
         ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject *x, ypObject **exc);
 
 // Equivalent to yp_setindexC(sequence, yp_asssizeC(key, exc), x, exc).
 ypAPI void yp_setitem(ypObject *sequence, ypObject *key, ypObject *x, ypObject **exc);
 
-// Removes the i-th item from sequence. On error, *exc is set to an exception.
+// Removes the i-th item from sequence. Sets *exc on error.
 ypAPI void yp_delindexC(ypObject *sequence, yp_ssize_t i, ypObject **exc);
 
-// Removes the elements of the slice from sequence, from i to j with step k. The Python-
-// equivalent "defaults" for i and j are yp_SLICE_DEFAULT, while for k it is 1. On error,
-// *exc is set to an exception.
-ypAPI void yp_delsliceC4(
+// Removes the elements of the slice from sequence, from i to j with step k. The Python- equivalent
+// "defaults" for i and j are yp_SLICE_DEFAULT, while for k it is 1. Sets *exc on error.
+ypAPI void yp_delsliceC5(
         ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject **exc);
 
 // Equivalent to yp_delindexC(sequence, yp_asssizeC(key, exc), exc).
 ypAPI void yp_delitem(ypObject *sequence, ypObject *key, ypObject **exc);
 
-// Appends x to the end of sequence. On error, *exc is set to an exception.
+// Appends x to the end of sequence. Sets *exc on error.
 ypAPI void yp_append(ypObject *sequence, ypObject *x, ypObject **exc);
 ypAPI void yp_push(ypObject *sequence, ypObject *x, ypObject **exc);
 
-// Appends the contents of t to the end of sequence. On error, *exc is set to an exception.
+// Appends the contents of t to the end of sequence. Sets *exc on error.
 ypAPI void yp_extend(ypObject *sequence, ypObject *t, ypObject **exc);
 
 // Appends the contents of sequence to itself factor-1 times; if factor is zero sequence is cleared.
-// Equivalent to seq*=factor for lists in Python. On error, *exc is set to an exception.
+// Equivalent to seq*=factor for lists in Python. Sets *exc on error.
 ypAPI void yp_irepeatC(ypObject *sequence, yp_ssize_t factor, ypObject **exc);
 
-// Inserts x into sequence at the index given by i; existing elements are shifted to make room.
-// On error, *exc is set to an exception.
+// Inserts x into sequence at the index given by i; existing elements are shifted to make room. Sets
+// *exc on error.
 ypAPI void yp_insertC(ypObject *sequence, yp_ssize_t i, ypObject *x, ypObject **exc);
 
 // Removes the i-th item from sequence and returns it. The Python-equivalent "default" for i is -1.
@@ -712,24 +710,22 @@ ypAPI ypObject *yp_popindexC(ypObject *sequence, yp_ssize_t i);
 ypAPI ypObject *yp_pop(ypObject *sequence);
 
 // Removes the first item from sequence that equals x. Raises yp_ValueError if x is not contained in
-// sequence. On error, *exc is set to an exception.
+// sequence. Sets *exc on error.
 ypAPI void yp_remove(ypObject *sequence, ypObject *x, ypObject **exc);
 
 // Removes the first item from sequence that equals x. Does _not_ raise an exception if x is not
-// contained in sequence. On error, *exc is set to an exception.
+// contained in sequence. Sets *exc on error.
 ypAPI void yp_discard(ypObject *sequence, ypObject *x, ypObject **exc);
 
-// Reverses the items of sequence in-place. On error, *exc is set to an exception.
+// Reverses the items of sequence in-place. Sets *exc on error.
 ypAPI void yp_reverse(ypObject *sequence, ypObject **exc);
 
 // Sorts the items of sequence in-place. key is a one-argument function used to extract a comparison
 // key from each element in iterable; to compare the elements directly, use yp_None. If reverse is
-// true, the list elements are sorted as if each comparison were reversed. On error, *exc is set to
-// an exception.
-// FIXME sort4?!?!
-ypAPI void yp_sort3(ypObject *sequence, ypObject *key, ypObject *reverse, ypObject **exc);
+// true, the list elements are sorted as if each comparison were reversed. Sets *exc on error.
+ypAPI void yp_sort4(ypObject *sequence, ypObject *key, ypObject *reverse, ypObject **exc);
 
-// Equivalent to yp_sort3(sequence, yp_None, yp_False, exc).
+// Equivalent to yp_sort4(sequence, yp_None, yp_False, exc).
 ypAPI void yp_sort(ypObject *sequence, ypObject **exc);
 
 // When given to a slice-like start/stop C argument, signals that the default "end" value be
@@ -803,43 +799,48 @@ ypAPI ypObject *yp_differenceNV(ypObject *set, int n, va_list args);
 // either set or x but not both.
 ypAPI ypObject *yp_symmetric_difference(ypObject *set, ypObject *x);
 
-// Add the elements from the n objects to set. On error, *exc is set to an exception.
-// FIXME exc after varargs?!?!?
-ypAPI void yp_updateN(ypObject *set, int n, ...);
-ypAPI void yp_updateNV(ypObject *set, int n, va_list args);
+// Add the elements from the n objects to set. Sets *exc on error. Note that exc is before n as you
+// cannot have arguments after ellipsis.
+ypAPI void yp_updateN(ypObject *set, ypObject **exc, int n, ...);
+ypAPI void yp_updateNV(ypObject *set, ypObject **exc, int n, va_list args);
 
-// Removes elements from set that are not contained in all n objects. On error, *exc is set to an
-// exception.
-// FIXME exc after varargs?!?!?
-ypAPI void yp_intersection_updateN(ypObject *set, int n, ...);
-ypAPI void yp_intersection_updateNV(ypObject *set, int n, va_list args);
+// Equivalent to yp_updateN(set, exc, 1, x).
+ypAPI void yp_update(ypObject *set, ypObject *x, ypObject **exc);
 
-// Removes elements from set that are contained in any of the n objects. On error, *exc is set to an
-// exception.
-// FIXME exc after varargs?!?!?
-ypAPI void yp_difference_updateN(ypObject *set, int n, ...);
-ypAPI void yp_difference_updateNV(ypObject *set, int n, va_list args);
+// Removes elements from set that are not contained in all n objects. Sets *exc on error. Note that
+// exc is before n as you cannot have arguments after ellipsis.
+ypAPI void yp_intersection_updateN(ypObject *set, ypObject **exc, int n, ...);
+ypAPI void yp_intersection_updateNV(ypObject *set, ypObject **exc, int n, va_list args);
+
+// Equivalent to yp_intersection_updateN(set, exc, 1, x).
+ypAPI void yp_intersection_update(ypObject *set, ypObject *x, ypObject **exc);
+
+// Removes elements from set that are contained in any of the n objects. Sets *exc on error. Note
+// that exc is before n as you cannot have arguments after ellipsis.
+ypAPI void yp_difference_updateN(ypObject *set, ypObject **exc, int n, ...);
+ypAPI void yp_difference_updateNV(ypObject *set, ypObject **exc, int n, va_list args);
+
+// Equivalent to yp_difference_updateN(set, exc, 1, x).
+ypAPI void yp_difference_update(ypObject *set, ypObject *x, ypObject **exc);
 
 // Removes elements from set that are contained in x, and adds elements from x not contained in set.
-// On error, *exc is set to an exception.
+// Sets *exc on error.
 ypAPI void yp_symmetric_difference_update(ypObject *set, ypObject *x, ypObject **exc);
 
-// Adds element x to set. On error, *exc is set to an exception. While Python calls this method add,
-// yp_add is already used for "a+b", so these two equivalent aliases are provided instead.
+// Adds element x to set. Sets *exc on error. While Python calls this method add, yp_add is already
+// used for "a+b", so these two equivalent aliases are provided instead.
 ypAPI void yp_push(ypObject *set, ypObject *x, ypObject **exc);
 ypAPI void yp_set_add(ypObject *set, ypObject *x, ypObject **exc);
 
 // If x is already contained in set, raises yp_KeyError; otherwise, adds x to set. Sets *exc on
 // error.
-// FIXME Ensure consistency everywhere on the language I use for "*exc on error".
 ypAPI void yp_pushunique(ypObject *set, ypObject *x, ypObject **exc);
 
-// Removes element x from set. Raises yp_KeyError if x is not contained in set. On error, *exc is
-// set to an exception.
+// Removes element x from set. Raises yp_KeyError if x is not contained in set. Sets *exc on error.
 ypAPI void yp_remove(ypObject *set, ypObject *x, ypObject **exc);
 
-// Removes element x from set. Does _not_ raise an exception if x is not contained in set. On
-// error, *exc is set to an exception.
+// Removes element x from set. Does _not_ raise an exception if x is not contained in set. Sets *exc
+// on error.
 ypAPI void yp_discard(ypObject *set, ypObject *x, ypObject **exc);
 
 // Removes an arbitrary item from set and returns a new reference to it. You cannot use the order of
@@ -854,11 +855,11 @@ ypAPI ypObject *const yp_frozenset_empty;
  * Mapping Operations
  */
 
-// frozendicts and dicts are both mapping objects. Note that yp_contains, yp_in, yp_not_in,
-// and yp_iter operate solely on a mapping's keys.
+// frozendicts and dicts are both mapping objects. Note that yp_contains, yp_in, yp_not_in, and
+// yp_iter operate solely on a mapping's keys.
 
-// Returns a new reference to the value of mapping with the given key. Returns yp_KeyError if key
-// is not in the map.
+// Returns a new reference to the value of mapping with the given key. Returns yp_KeyError if key is
+// not in the map.
 ypAPI ypObject *yp_getitem(ypObject *mapping, ypObject *key);
 
 // Similar to yp_getitem, but returns a new reference to defval if key is not in the map. defval
@@ -874,12 +875,11 @@ ypAPI ypObject *yp_iter_keys(ypObject *mapping);
 // Returns a new reference to an iterator that yields mapping's values.
 ypAPI ypObject *yp_iter_values(ypObject *mapping);
 
-// Adds or replaces the value of mapping with the given key, setting it to x. On error, *exc is set
-// to an exception.
+// Adds or replaces the value of mapping with the given key, setting it to x. Sets *exc on error.
 ypAPI void yp_setitem(ypObject *mapping, ypObject *key, ypObject *x, ypObject **exc);
 
-// Removes the item with the given key from mapping. Raises yp_KeyError if key is not in mapping. On
-// error, *exc is set to an exception.
+// Removes the item with the given key from mapping. Raises yp_KeyError if key is not in mapping.
+// Sets *exc on error.
 ypAPI void yp_delitem(ypObject *mapping, ypObject *key, ypObject **exc);
 
 // If key is in mapping, remove it and return a new reference to its value, else return a new
@@ -902,17 +902,18 @@ ypAPI void yp_popitem(ypObject *mapping, ypObject **key, ypObject **value);
 ypAPI ypObject *yp_setdefault(ypObject *mapping, ypObject *key, ypObject *defval);
 
 // Add the given n key/value pairs (for a total of 2*n objects) to mapping, overwriting existing
-// keys. If a given key is seen more than once, the last value is retained. On error, *exc is set to
-// an exception.
-// FIXME exc and vararg
-ypAPI void yp_updateK(ypObject *mapping, int n, ...);
-ypAPI void yp_updateKV(ypObject *mapping, int n, va_list args);
+// keys. If a given key is seen more than once, the last value is retained. Sets *exc on error. Note
+// that exc is before n as you cannot have arguments after ellipsis.
+ypAPI void yp_updateK(ypObject *mapping, ypObject **exc, int n, ...);
+ypAPI void yp_updateKV(ypObject *mapping, ypObject **exc, int n, va_list args);
 
-// Add the elements from the n objects to mapping. Each object is handled as per yp_dict. On error,
-// *exc is set to an exception.
-// FIXME exc and vararg
-ypAPI void yp_updateN(ypObject *mapping, int n, ...);
-ypAPI void yp_updateNV(ypObject *mapping, int n, va_list args);
+// Add the elements from the n objects to mapping. Each object is handled as per yp_dict. Sets *exc
+// on error. Note that exc is before n as you cannot have arguments after ellipsis.
+ypAPI void yp_updateN(ypObject *mapping, ypObject **exc, int n, ...);
+ypAPI void yp_updateNV(ypObject *mapping, ypObject **exc, int n, va_list args);
+
+// Equivalent to yp_updateN(mapping, exc, 1, x).
+ypAPI void yp_update(ypObject *mapping, ypObject *x, ypObject **exc);
 
 // Immortal empty frozendict object.
 ypAPI ypObject *const yp_frozendict_empty;
@@ -923,16 +924,16 @@ ypAPI ypObject *const yp_frozendict_empty;
  */
 
 // These methods are supported by bytes and str (and their mutable counterparts, of course).
-// Individual elements of bytes and bytearrays are ints, so yp_getindexC will always return ints
-// for these types, and will only accept ints for yp_setindexC. The individual elements of strs and
-// chrarrays are single-character strs. Using bytes/bytearray arguments on a str/chrarray method,
-// or str/chrarray arguments on a bytes/bytearray method, raises yp_TypeError (unless otherwise
+// Individual elements of bytes and bytearrays are ints, so yp_getindexC will always return ints for
+// these types, and will only accept ints for yp_setindexC. The individual elements of strs and
+// chrarrays are single-character strs. Using bytes/bytearray arguments on a str/chrarray method, or
+// str/chrarray arguments on a bytes/bytearray method, raises yp_TypeError (unless otherwise
 // documented).
 
-// Slicing an object always returns an object of the same type, so yp_getsliceC4 on a bytearray
-// will return a bytearray, while a slice of a str is another str, and so forth.
+// Slicing an object always returns an object of the same type, so yp_getsliceC4 on a bytearray will
+// return a bytearray, while a slice of a str is another str, and so forth.
 
-// Unlike Python, the arguments start/end (yp_startswithC4 et al) and i/j (yp_findC4 et al) are
+// Unlike Python, the arguments start/end (yp_startswithC4 et al) and i/j (yp_findC5 et al) are
 // always treated as in slice notation. Python behaves peculiarly when end<start in certain edge
 // cases involving empty strings (compare "foo"[5:0].startswith("") to "foo".startswith("", 5, 0)).
 
@@ -965,9 +966,9 @@ ypAPI ypObject *const yp_s_surrogatepass;      // "surrogatepass"
 ypAPI ypObject *yp_isalnum(ypObject *s);
 
 // Returns the immortal yp_True if all characters in s are alphabetic and there is at least one
-// character, otherwise yp_False. Alphabetic characters are those characters defined in the
-// Unicode character database as "Letter". Note that this is different from the "Alphabetic"
-// property defined in the Unicode Standard.
+// character, otherwise yp_False. Alphabetic characters are those characters defined in the Unicode
+// character database as "Letter". Note that this is different from the "Alphabetic" property
+// defined in the Unicode Standard.
 ypAPI ypObject *yp_isalpha(ypObject *s);
 
 // Returns the immortal yp_True if all characters in s are decimal characters and there is at least
@@ -983,36 +984,36 @@ ypAPI ypObject *yp_isdigit(ypObject *s);
 // definition, otherwise yp_False.
 ypAPI ypObject *yp_isidentifier(ypObject *s);
 
-// Returns the immortal yp_True if all cased characters in s are lowercase and there is at least
-// one cased character, otherwise yp_False. Cased characters are those with a general category
-// property of "Lu", "Ll", or "Lt".
+// Returns the immortal yp_True if all cased characters in s are lowercase and there is at least one
+// cased character, otherwise yp_False. Cased characters are those with a general category property
+// of "Lu", "Ll", or "Lt".
 ypAPI ypObject *yp_islower(ypObject *s);
 
-// Returns the immortal yp_True if all characters in s are numeric characters and there is at
-// least one character, otherwise yp_False. Numeric characters are those that have the Unicode
-// numeric value property.
+// Returns the immortal yp_True if all characters in s are numeric characters and there is at least
+// one character, otherwise yp_False. Numeric characters are those that have the Unicode numeric
+// value property.
 ypAPI ypObject *yp_isnumeric(ypObject *s);
 
 // Returns the immortal yp_True if all characters in s are printable or s is empty, otherwise
-// yp_False. Nonprintable characters are those characters defined in the Unicode character
-// database as "Other" or "Separator", excepting space (0x20) which is considered printable.
+// yp_False. Nonprintable characters are those characters defined in the Unicode character database
+// as "Other" or "Separator", excepting space (0x20) which is considered printable.
 ypAPI ypObject *yp_isprintable(ypObject *s);
 
 // Returns the immortal yp_True if there are only whitespace characters in s and there is at least
 // one character, otherwise yp_False. Whitespace characters are those characters defined in the
-// Unicode character database as "Other" or "Separator" and those with bidirectional property
-// being one of "WS", "B", or "S".
+// Unicode character database as "Other" or "Separator" and those with bidirectional property being
+// one of "WS", "B", or "S".
 ypAPI ypObject *yp_isspace(ypObject *s);
 
-// Returns the immortal yp_True if all cased characters in s are uppercase and there is at least
-// one cased character, otherwise yp_False. Cased characters are those with a general category
-// property of "Lu", "Ll", or "Lt".
+// Returns the immortal yp_True if all cased characters in s are uppercase and there is at least one
+// cased character, otherwise yp_False. Cased characters are those with a general category property
+// of "Lu", "Ll", or "Lt".
 ypAPI ypObject *yp_isupper(ypObject *s);
 
 // Returns the immortal yp_True if s[start:end] starts with the specified prefix, otherwise
-// yp_False. prefix can also be a tuple of prefix strings for which to look. If a prefix string
-// is empty, returns yp_True. yp_startswith considers the entire string (as if start is 0 and end
-// is yp_SLICE_USELEN).
+// yp_False. prefix can also be a tuple of prefix strings for which to look. If a prefix string is
+// empty, returns yp_True. yp_startswith considers the entire string (as if start is 0 and end is
+// yp_SLICE_USELEN).
 ypAPI ypObject *yp_startswithC4(ypObject *s, ypObject *prefix, yp_ssize_t start, yp_ssize_t end);
 ypAPI ypObject *yp_startswith(ypObject *s, ypObject *prefix);
 
@@ -1032,8 +1033,8 @@ ypAPI ypObject *yp_upper(ypObject *s);
 // casefolding algorithm is described in section 3.13 of the Unicode Standard.
 ypAPI ypObject *yp_casefold(ypObject *s);
 
-// Returns a new reference to a copy of s with uppercase characters converted to lowercase and
-// vice versa.
+// Returns a new reference to a copy of s with uppercase characters converted to lowercase and vice
+// versa.
 ypAPI ypObject *yp_swapcase(ypObject *s);
 
 // Returns a new reference to a copy of s with its first character capitalized and the rest
@@ -1079,8 +1080,8 @@ ypAPI ypObject *yp_rstrip(ypObject *s);
 ypAPI ypObject *yp_strip2(ypObject *s, ypObject *chars);
 ypAPI ypObject *yp_strip(ypObject *s);
 
-// Returns a new reference to the concatenation of the strings in iterable, using s as the
-// separator between elements. Raises yp_TypeError if there are any non-string values.
+// Returns a new reference to the concatenation of the strings in iterable, using s as the separator
+// between elements. Raises yp_TypeError if there are any non-string values.
 ypAPI ypObject *yp_join(ypObject *s, ypObject *iterable);
 
 // Equivalent to yp_join(s, yp_tupleN(n, ...)).
@@ -1089,29 +1090,29 @@ ypAPI ypObject *yp_joinNV(ypObject *s, int n, va_list args);
 
 // Splits s at the first occurrence of sep and returns new references to 3 objects: *part0 is the
 // part before the separator, *part1 the separator itself, and *part2 the part after. If the
-// separator is not found, *part0 is a copy of s, and *part1 and *part2 are empty strings. Sets
-// all 3 ypObject**s to the same exception on error.
+// separator is not found, *part0 is a copy of s, and *part1 and *part2 are empty strings. Sets all
+// 3 ypObject**s to the same exception on error.
 ypAPI void yp_partition(
         ypObject *s, ypObject *sep, ypObject **part0, ypObject **part1, ypObject **part2);
 
-// Similar to yp_partition, except s is split at the last occurrence of sep, and if the separator
-// is not found then *part0 and *part1 are empty strings, and *part2 is a copy of s.
+// Similar to yp_partition, except s is split at the last occurrence of sep, and if the separator is
+// not found then *part0 and *part1 are empty strings, and *part2 is a copy of s.
 ypAPI void yp_rpartition(
         ypObject *s, ypObject *sep, ypObject **part0, ypObject **part1, ypObject **part2);
 
-// Returns a new reference to a list of words in the string, using sep as the delimiter string.
-// For yp_splitC3, only performs the leftmost splits up to maxsplit; for yp_split2, or if maxsplit
-// is -1, there is no limit on the number of splits made. If sep is yp_None this behaves as
-// yp_split, otherwise consecutive delimiters are not grouped together and are deemed to delimit
-// empty strings.
+// Returns a new reference to a list of words in the string, using sep as the delimiter string. For
+// yp_splitC3, only performs the leftmost splits up to maxsplit; for yp_split2, or if maxsplit is
+// -1, there is no limit on the number of splits made. If sep is yp_None this behaves as yp_split,
+// otherwise consecutive delimiters are not grouped together and are deemed to delimit empty
+// strings.
 //
 // Ex: yp_split2("1,,2", ",") returns ["1", "", "2"]
 ypAPI ypObject *yp_splitC3(ypObject *s, ypObject *sep, yp_ssize_t maxsplit);
 ypAPI ypObject *yp_split2(ypObject *s, ypObject *sep);
 
 // Similar to yp_splitC3, except a different splitting algorithm is used. Runs of consecutive
-// whitespace are regarded as a single separator and the result will contain no empty strings at
-// the start or end if the string has leading or trailing whitespace.
+// whitespace are regarded as a single separator and the result will contain no empty strings at the
+// start or end if the string has leading or trailing whitespace.
 //
 // Ex: yp_split(" 1  2   3  ") returns ["1", "2", "3"]
 ypAPI ypObject *yp_split(ypObject *s);
@@ -1156,8 +1157,8 @@ ypAPI ypObject *yp_formatN(ypObject *s, int n, ...);
 ypAPI ypObject *yp_formatNV(ypObject *s, int n, va_list args);
 
 // Similar to yp_formatN, except each replacement field contains the name of one of the n key/value
-// pairs (for a total of 2*n objects). (Implementation note: this function is optimized for
-// in-order replacement field names.)
+// pairs (for a total of 2*n objects). (Implementation note: this function is optimized for in-order
+// replacement field names.)
 ypAPI ypObject *yp_formatK(ypObject *s, int n, ...);
 ypAPI ypObject *yp_formatKV(ypObject *s, int n, va_list args);
 
@@ -1247,8 +1248,8 @@ typedef struct _yp_function_decl_t {
     // Array of parameters. Errors in this array generally raise yp_ParameterSyntaxError.
     yp_parameter_decl_t *parameters;
 
-    // Additional data that will be made available to code via yp_function_stateCX. Can be NULL.
-    // See yp_state_decl_t for more details.
+    // Additional data that will be made available to code via yp_function_stateCX. Can be NULL. See
+    // yp_state_decl_t for more details.
     void *state;
 
     // Describes the layout of state. If NULL, no state is copied into the object.
@@ -1305,67 +1306,56 @@ ypAPI ypObject *yp_xor(ypObject *x, ypObject *y);
 ypAPI ypObject *yp_bar(ypObject *x, ypObject *y);
 ypAPI ypObject *yp_invert(ypObject *x);
 
-// In-place versions of the above; if the object *x can be modified to hold the result, it is,
-// otherwise *x is discarded and replaced with the result. If *x is immutable on input, an
-// immutable object is returned, otherwise a mutable object is returned. On error, *x is
-// discarded and set to an exception.
-// FIXME Rethink these inplace things. Why are we modifying mutables and replacing immutables?
-// Is it the Python library, or its syntax, that technically is implementing this?
-// FIXME Also stop discarding inputs...never steal an input!!
-ypAPI void yp_iadd(ypObject **x, ypObject *y);
-ypAPI void yp_isub(ypObject **x, ypObject *y);
-ypAPI void yp_imul(ypObject **x, ypObject *y);
-ypAPI void yp_itruediv(ypObject **x, ypObject *y);
-ypAPI void yp_ifloordiv(ypObject **x, ypObject *y);
-ypAPI void yp_imod(ypObject **x, ypObject *y);
-ypAPI void yp_ipow(ypObject **x, ypObject *y);
-ypAPI void yp_ipow3(ypObject **x, ypObject *y, ypObject *z);
-ypAPI void yp_ineg(ypObject **x);
-ypAPI void yp_ipos(ypObject **x);
-ypAPI void yp_iabs(ypObject **x);
-ypAPI void yp_ilshift(ypObject **x, ypObject *y);
-ypAPI void yp_irshift(ypObject **x, ypObject *y);
-ypAPI void yp_iamp(ypObject **x, ypObject *y);
-ypAPI void yp_ixor(ypObject **x, ypObject *y);
-ypAPI void yp_ibar(ypObject **x, ypObject *y);
-ypAPI void yp_iinvert(ypObject **x);
+// In-place versions of the above. Modifies x to hold the result. Sets *exc on error. Unlike Python,
+// x must be mutable (Python's __iadd__ et al return a new object if x is immutable).
+ypAPI void yp_iadd(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_isub(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_imul(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_itruediv(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_ifloordiv(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_imod(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_ipow(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_ipow4(ypObject *x, ypObject *y, ypObject *z, ypObject **exc);
+ypAPI void yp_ineg(ypObject *x, ypObject **exc);
+ypAPI void yp_ipos(ypObject *x, ypObject **exc);
+ypAPI void yp_iabs(ypObject *x, ypObject **exc);
+ypAPI void yp_ilshift(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_irshift(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_iamp(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_ixor(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_ibar(ypObject *x, ypObject *y, ypObject **exc);
+ypAPI void yp_iinvert(ypObject *x, ypObject **exc);
 
-// Versions of yp_iadd et al that accept a C integer as the second argument. Remember that *x may
-// be discarded and replaced with the result.
-// FIXME Rethink (see above).
-// FIXME Also stop discarding inputs...never steal an input!!
-ypAPI void yp_iaddC(ypObject **x, yp_int_t y);
-ypAPI void yp_isubC(ypObject **x, yp_int_t y);
-ypAPI void yp_imulC(ypObject **x, yp_int_t y);
-ypAPI void yp_itruedivC(ypObject **x, yp_int_t y);
-ypAPI void yp_ifloordivC(ypObject **x, yp_int_t y);
-ypAPI void yp_imodC(ypObject **x, yp_int_t y);
-ypAPI void yp_ipowC(ypObject **x, yp_int_t y);
-ypAPI void yp_ipowC3(ypObject **x, yp_int_t y, yp_int_t z);
-ypAPI void yp_ilshiftC(ypObject **x, yp_int_t y);
-ypAPI void yp_irshiftC(ypObject **x, yp_int_t y);
-ypAPI void yp_iampC(ypObject **x, yp_int_t y);
-ypAPI void yp_ixorC(ypObject **x, yp_int_t y);
-ypAPI void yp_ibarC(ypObject **x, yp_int_t y);
+// Versions of yp_iadd et al that accept a C integer as the second argument.
+ypAPI void yp_iaddC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_isubC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_imulC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_itruedivC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_ifloordivC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_imodC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_ipowC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_ipowC4(ypObject *x, yp_int_t y, yp_int_t z, ypObject **exc);
+ypAPI void yp_ilshiftC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_irshiftC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_iampC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_ixorC(ypObject *x, yp_int_t y, ypObject **exc);
+ypAPI void yp_ibarC(ypObject *x, yp_int_t y, ypObject **exc);
 
-// Versions of yp_iadd et al that accept a C floating-point as the second argument. Remember that
-// *x may be discarded and replaced with the result.
-// FIXME Rethink (see above).
-// FIXME Also stop discarding inputs...never steal an input!!
-ypAPI void yp_iaddCF(ypObject **x, yp_float_t y);
-ypAPI void yp_isubCF(ypObject **x, yp_float_t y);
-ypAPI void yp_imulCF(ypObject **x, yp_float_t y);
-ypAPI void yp_itruedivCF(ypObject **x, yp_float_t y);
-ypAPI void yp_ifloordivCF(ypObject **x, yp_float_t y);
-ypAPI void yp_imodCF(ypObject **x, yp_float_t y);
-ypAPI void yp_ipowCF(ypObject **x, yp_float_t y);
+// Versions of yp_iadd et al that accept a C floating-point as the second argument.
+ypAPI void yp_iaddCF(ypObject *x, yp_float_t y, ypObject **exc);
+ypAPI void yp_isubCF(ypObject *x, yp_float_t y, ypObject **exc);
+ypAPI void yp_imulCF(ypObject *x, yp_float_t y, ypObject **exc);
+ypAPI void yp_itruedivCF(ypObject *x, yp_float_t y, ypObject **exc);
+ypAPI void yp_ifloordivCF(ypObject *x, yp_float_t y, ypObject **exc);
+ypAPI void yp_imodCF(ypObject *x, yp_float_t y, ypObject **exc);
+ypAPI void yp_ipowCF(ypObject *x, yp_float_t y, ypObject **exc);
 
 // Library routines for nohtyP integer operations on C types. Returns zero and sets *exc on error.
 // Additional notes:
 //
 // - yp_truedivL returns a floating-point number
-// - If z is 0, yp_powL3 returns x to the power y, otherwise x to the power y modulo z
-// - If y is negative, yp_powL and yp_powL3 raise yp_ValueError, as the result should be a
+// - If z is 0, yp_powL4 returns x to the power y, otherwise x to the power y modulo z
+// - If y is negative, yp_powL and yp_powL4 raise yp_ValueError, as the result should be a
 //   floating-point number; use yp_powLF for negative exponents instead
 ypAPI yp_int_t   yp_addL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI yp_int_t   yp_subL(yp_int_t x, yp_int_t y, ypObject **exc);
@@ -1375,7 +1365,7 @@ ypAPI yp_int_t   yp_floordivL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI yp_int_t   yp_modL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI void       yp_divmodL(yp_int_t x, yp_int_t y, yp_int_t *div, yp_int_t *mod, ypObject **exc);
 ypAPI yp_int_t   yp_powL(yp_int_t x, yp_int_t y, ypObject **exc);
-ypAPI yp_int_t   yp_powL3(yp_int_t x, yp_int_t y, yp_int_t z, ypObject **exc);
+ypAPI yp_int_t   yp_powL4(yp_int_t x, yp_int_t y, yp_int_t z, ypObject **exc);
 ypAPI yp_int_t   yp_negL(yp_int_t x, ypObject **exc);
 ypAPI yp_int_t   yp_posL(yp_int_t x, ypObject **exc);
 ypAPI yp_int_t   yp_absL(yp_int_t x, ypObject **exc);
@@ -1386,8 +1376,8 @@ ypAPI yp_int_t   yp_xorL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI yp_int_t   yp_barL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI yp_int_t   yp_invertL(yp_int_t x, ypObject **exc);
 
-// Library routines for nohtyP floating-point operations on C types. Returns zero and sets *exc
-// on error.
+// Library routines for nohtyP floating-point operations on C types. Returns zero and sets *exc on
+// error.
 ypAPI yp_float_t yp_addLF(yp_float_t x, yp_float_t y, ypObject **exc);
 ypAPI yp_float_t yp_subLF(yp_float_t x, yp_float_t y, ypObject **exc);
 ypAPI yp_float_t yp_mulLF(yp_float_t x, yp_float_t y, ypObject **exc);
@@ -1401,9 +1391,9 @@ ypAPI yp_float_t yp_negLF(yp_float_t x, ypObject **exc);
 ypAPI yp_float_t yp_posLF(yp_float_t x, ypObject **exc);
 ypAPI yp_float_t yp_absLF(yp_float_t x, ypObject **exc);
 
-// Conversion routines from C types or objects to C types. Returns a reasonable value and sets
-// *exc on error; "reasonable" usually means "truncated". Converting a float to an int truncates
-// toward zero but is not an error.
+// Conversion routines from C types or objects to C types. Returns a reasonable value and sets *exc
+// on error; "reasonable" usually means "truncated". Converting a float to an int truncates toward
+// zero but is not an error.
 ypAPI yp_int_t     yp_asintC(ypObject *x, ypObject **exc);
 ypAPI yp_int8_t    yp_asint8C(ypObject *x, ypObject **exc);
 ypAPI yp_uint8_t   yp_asuint8C(ypObject *x, ypObject **exc);
@@ -1463,11 +1453,11 @@ ypAPI ypObject *const yp_i_two;
 // Unlike Python, most objects are deep copied in memory, even immutables, as deep copying is one
 // strategy to maintain threadsafety.
 
-// Transmutes x to its associated immutable type. If x is already immutable this is a no-op. On
-// error, *exc is set to an exception.
+// Transmutes x to its associated immutable type. If x is already immutable this is a no-op. Sets
+// *exc on error.
 ypAPI void yp_freeze(ypObject *x, ypObject **exc);
 
-// Freezes x and, recursively, all contained objects. On error, *exc is set to an exception.
+// Freezes x and, recursively, all contained objects. Sets *exc on error.
 ypAPI void yp_deepfreeze(ypObject *x, ypObject **exc);
 
 // Returns a new reference to a mutable shallow copy of x. If x has no associated mutable type an
@@ -1500,12 +1490,12 @@ ypAPI ypObject *yp_deepcopy(ypObject *x);
 
 // Discards all contained objects in x, deallocates _some_ memory, and transmutes it to the
 // ypInvalidated type (rendering the object useless). If x is immortal or already invalidated this
-// is a no-op; immutable objects _can_ be invalidated. On error, *exc is set to an exception.
+// is a no-op; immutable objects _can_ be invalidated. Sets *exc on error.
 ypAPI void yp_invalidate(ypObject *x, ypObject **exc);
 
 // Invalidates x and, recursively, all contained objects. As nohtyP does not currently detect
 // reference cycles during garbage collection, this is an effective way to break cycles and free
-// memory. On error, *exc is set to an exception.
+// memory. Sets *exc on error.
 ypAPI void yp_deepinvalidate(ypObject *x, ypObject **exc);
 
 
@@ -1570,8 +1560,8 @@ typedef struct _yp_state_decl_t {
     // The total size of state, in bytes.
     yp_ssize_t size;
 
-    // The number of elements in the offsets array, or -1 to calculate the offsets (see offsets
-    // for details).
+    // The number of elements in the offsets array, or -1 to calculate the offsets (see offsets for
+    // details).
     yp_ssize_t offsets_len;
 
     // An array of offsets of the objects in state (i.e., the ypObject * members). Identifying these
@@ -1630,9 +1620,9 @@ ypAPI ypObject *yp_miniiter(ypObject *x, yp_uint64_t *state);
 // exhausted yp_StopIteration is raised.
 ypAPI ypObject *yp_miniiter_next(ypObject *mi, yp_uint64_t *state);
 
-// Returns a hint as to how many items are left to be yielded. See yp_length_hintC for
-// additional information. state must point to the same data returned by the previous yp_miniiter*
-// call. Returns zero and sets *exc on error.
+// Returns a hint as to how many items are left to be yielded. See yp_length_hintC for additional
+// information. state must point to the same data returned by the previous yp_miniiter* call.
+// Returns zero and sets *exc on error.
 ypAPI yp_ssize_t yp_miniiter_length_hintC(ypObject *mi, yp_uint64_t *state, ypObject **exc);
 
 // Mini iterator versions of yp_iter_keys and yp_iter_values. Otherwise behaves as yp_miniiter.
@@ -1662,9 +1652,9 @@ ypAPI void yp_miniiter_items_next(
 // when dealing with containers. Keep in mind, though, that many of these functions create
 // short-lived objects internally, so excessive use may impact execution time.
 
-// For functions that deal with strs, if encoding is missing yp_s_utf_8 (which is compatible
-// with ascii) is assumed, while if errors is missing yp_s_strict is assumed. yp_*_containsC
-// returns false and sets *exc on exception.
+// For functions that deal with strs, if encoding is missing yp_s_utf_8 (which is compatible with
+// ascii) is assumed, while if errors is missing yp_s_strict is assumed. yp_*_containsC returns
+// false and sets *exc on exception.
 
 // Operations on containers that map objects to integers.
 ypAPI int      yp_o2i_containsC(ypObject *container, yp_int_t x, ypObject **exc);
@@ -1677,8 +1667,8 @@ ypAPI void     yp_o2i_setitemC(ypObject *container, ypObject *key, yp_int_t x, y
 ypAPI void yp_o2s_setitemC4(
         ypObject **container, ypObject *key, const yp_uint8_t *x, yp_ssize_t x_len);
 
-// Operations on containers that map integers to objects. Note that if the container is known
-// at compile-time to be a sequence, then yp_getindexC et al are better choices.
+// Operations on containers that map integers to objects. Note that if the container is known at
+// compile-time to be a sequence, then yp_getindexC et al are better choices.
 ypAPI ypObject *yp_i2o_getitemC(ypObject *container, yp_int_t key);
 ypAPI void      yp_i2o_setitemC(ypObject *container, yp_int_t key, ypObject *x, ypObject **exc);
 
@@ -1690,8 +1680,8 @@ ypAPI void     yp_i2i_setitemC(ypObject *container, yp_int_t key, yp_int_t x, yp
 ypAPI void yp_i2s_setitemC4(
         ypObject **container, yp_int_t key, const yp_uint8_t *x, yp_ssize_t x_len);
 
-// Operations on containers that map strs to objects. Note that if the value of the str is
-// known at compile-time, as in:
+// Operations on containers that map strs to objects. Note that if the value of the str is known at
+// compile-time, as in:
 //
 //      value = yp_s2o_getitemC3(o, "mykey", -1);
 //
@@ -1704,7 +1694,7 @@ ypAPI void      yp_s2o_setitemC4(
              ypObject **container, const yp_uint8_t *key, yp_ssize_t key_len, ypObject *x);
 
 // Operations on containers that map strs to integers.
-ypAPI yp_int_t yp_s2i_getitemC3(
+ypAPI yp_int_t yp_s2i_getitemC4(
         ypObject *container, const yp_uint8_t *key, yp_ssize_t key_len, ypObject **exc);
 ypAPI void yp_s2i_setitemC4(
         ypObject **container, const yp_uint8_t *key, yp_ssize_t key_len, yp_int_t x);
@@ -1714,31 +1704,31 @@ ypAPI void yp_s2i_setitemC4(
  * Immortal "Constructor" Macros
  */
 
-// Defines an immortal int object at compile-time, which can be accessed by the variable name,
-// which is of type "ypObject * const". value is a (constant) yp_int_t. To be used as:
+// Defines an immortal int object at compile-time, which can be accessed by the variable name, which
+// is of type "ypObject * const". value is a (constant) yp_int_t. To be used as:
 //
 //      yp_IMMORTAL_INT(name, value);
 
 // Defines an immortal bytes object at compile-time, which can be accessed by the variable name,
-// which is of type "ypObject * const". value is a C string literal that can contain null bytes.
-// The length is calculated while compiling; the hash will be calculated the first time it is
-// accessed. To be used as:
+// which is of type "ypObject * const". value is a C string literal that can contain null bytes. The
+// length is calculated while compiling; the hash will be calculated the first time it is accessed.
+// To be used as:
 //
 //      yp_IMMORTAL_BYTES(name, value);
 
 // Defines an immortal str constant at compile-time, which can be accessed by the variable name,
-// which is of type "ypObject * const". value is a latin-1 encoded C string literal that can
-// contain null characters. The length is calculated while compiling; the hash will be calculated
-// the first time it is accessed. Note that this also accepts an ascii-encoded C string literal,
-// as ascii is a subset of latin-1.
+// which is of type "ypObject * const". value is a latin-1 encoded C string literal that can contain
+// null characters. The length is calculated while compiling; the hash will be calculated the first
+// time it is accessed. Note that this also accepts an ascii-encoded C string literal, as ascii is a
+// subset of latin-1.
 //
 //      yp_IMMORTAL_STR_LATIN_1(name, value);
 
 // The default immortal "constructor" macros declare variables as "ypObject * const". This means
-// immortals defined outside of a function will be extern. It also means you should *not*
-// use these macros in a function, as the variable will be "deallocated" when the function returns,
-// and immortals should never be deallocated. The following macros work as above, except the
-// variables are declared as "static ypObject * const".
+// immortals defined outside of a function will be extern. It also means you should *not* use these
+// macros in a function, as the variable will be "deallocated" when the function returns, and
+// immortals should never be deallocated. The following macros work as above, except the variables
+// are declared as "static ypObject * const".
 //
 //      yp_IMMORTAL_INT_static(name, value);
 //      yp_IMMORTAL_BYTES_static(name, value);
@@ -1886,8 +1876,8 @@ ypAPI void yp_mem_default_free(void *p);
  * Direct Object Memory Access
  */
 
-// XXX The "X" in these names is a reminder that the function is returning internal memory, and
-// as such should be used with caution.
+// XXX The "X" in these names is a reminder that the function is returning internal memory, and as
+// such should be used with caution.
 
 // Typically only called from within yp_generator_decl_t.func functions. Sets *state and *size to
 // the internal iterator state buffer and its size in bytes, and returns the immortal yp_None. The
@@ -1897,8 +1887,8 @@ ypAPI void yp_mem_default_free(void *p);
 // returns an exception on error.
 ypAPI ypObject *yp_iter_stateCX(ypObject *iterator, void **state, yp_ssize_t *size);
 
-// Typically only called from within yp_function_decl_t.code functions. Sets *state and *size to
-// the internal function state buffer and its size in bytes, and returns the immortal yp_None. The
+// Typically only called from within yp_function_decl_t.code functions. Sets *state and *size to the
+// internal function state buffer and its size in bytes, and returns the immortal yp_None. The
 // structure and initial values of *state are determined when the function is created; the size
 // cannot change after creation, and any ypObject*s in *state should be considered *borrowed* (it is
 // safe to replace them with new or immortal references). Sets *state to NULL, *size to zero, and
@@ -1915,12 +1905,12 @@ ypAPI ypObject *yp_asbytesCX(ypObject *seq, const yp_uint8_t **bytes, yp_ssize_t
 
 // str and chrarray internally store their Unicode characters in particular encodings, usually
 // depending on the contents of the string. This function sets *encoded to the beginning of that
-// data, *size to the number of bytes in encoded, and *encoding to the immortal str representing
-// the encoding used (yp_s_latin_1, perhaps). *encoded will point into internal object memory
-// which MUST NOT be modified; furthermore, the string itself must not be modified while using the
-// array. As a special case, if size is NULL, the string must not contain null characters and
-// *encoded will point to a null-terminated string. On error, sets *encoded to NULL, *size to
-// zero (if size is not NULL), *encoding to the exception, and returns the exception.
+// data, *size to the number of bytes in encoded, and *encoding to the immortal str representing the
+// encoding used (yp_s_latin_1, perhaps). *encoded will point into internal object memory which MUST
+// NOT be modified; furthermore, the string itself must not be modified while using the array. As a
+// special case, if size is NULL, the string must not contain null characters and *encoded will
+// point to a null-terminated string. On error, sets *encoded to NULL, *size to zero (if size is not
+// NULL), *encoding to the exception, and returns the exception.
 ypAPI ypObject *yp_asencodedCX(
         ypObject *seq, const yp_uint8_t **encoded, yp_ssize_t *size, ypObject **encoding);
 
@@ -1965,8 +1955,8 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
  */
 
 #ifdef yp_FUTURE
-// yp_IF: A series of macros to emulate an if/elif/else with exception handling. To be used
-// strictly as follows (including braces):
+// yp_IF: A series of macros to emulate an if/elif/else with exception handling. To be used strictly
+// as follows (including braces):
 //
 //      yp_IF(condition1) {
 //          // branch1
@@ -1984,8 +1974,8 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 // As in Python, a condition is only evaluated if previous conditions evaluated false and did not
 // raise an exception, the exception-branch is executed if any evaluated condition raises an
 // exception, and the exception target is only available inside exception-branch. Unlike Python,
-// exceptions in the chosen branch do not trigger the exception-branch. If a condition creates a
-// new reference that must be discarded, use yp_IFd and/or yp_ELIFd ("d" stands for "discard" or
+// exceptions in the chosen branch do not trigger the exception-branch. If a condition creates a new
+// reference that must be discarded, use yp_IFd and/or yp_ELIFd ("d" stands for "discard" or
 // "decref"):
 //
 //      yp_IFd(yp_getitem(a, key))
@@ -2039,8 +2029,8 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 // once for each successfully-yielded value, which is assigned to the target variable. This occurs
 // until:
 //
-// - the iterator raises yp_StopIteration (FIXME generator exit? others?), in which case else-suite
-//   is executed (but *not* the exception-suite)
+// - the iterator raises yp_StopIteration, in which case else-suite is executed (but *not* the
+//   exception-suite)
 // - a break statement, in which case neither the else- nor exception-suites are executed
 // - an exception occurs in expression or the iterator, in which case the exception target (which is
 //   only available inside exception-suite) is set to the exception and the exception-suite is
@@ -2125,8 +2115,7 @@ struct _ypObject {
 // These structures are likely to change in future versions; they should only exist in-memory
 struct _ypIntObject {
     _ypObject_HEAD;
-    // TODO If sizeof(yp_int_t)==sizeof(yp_hash_t), we _could_ use ob_hash instead of value,
-    // except:
+    // TODO If sizeof(yp_int_t)==sizeof(yp_hash_t), we _could_ use ob_hash instead of value, except:
     //
     // - ob_hash is currently only supposed to be for immutable values
     // - Value -1 gets mapped to hash -2, which if cached would *change the value* of "-1"

--- a/nohtyP.h
+++ b/nohtyP.h
@@ -96,7 +96,7 @@ extern "C" {
 #include <sys/types.h>
 
 // To link to nohtyP statically, simply add nohtyP.c to your project: no special defines are
-// required.  To link to nohtyP dynamically, first build nohtyP.c as a shared library with
+// required. To link to nohtyP dynamically, first build nohtyP.c as a shared library with
 // yp_ENABLE_SHARED and yp_BUILD_CORE, then include nohtyP.h with yp_ENABLE_SHARED.
 #ifdef yp_ENABLE_SHARED
 #if defined(_WIN32)
@@ -124,8 +124,8 @@ typedef struct _yp_state_decl_t            yp_state_decl_t;
  * Initialization
  */
 
-// Must be called once before any other function; subsequent calls are a no-op.  If a fatal error
-// occurs abort() is called.  args can be NULL to accept all defaults; further documentation
+// Must be called once before any other function; subsequent calls are a no-op. If a fatal error
+// occurs abort() is called. args can be NULL to accept all defaults; further documentation
 // on these parameters can be found below.
 ypAPI void yp_initialize(const yp_initialize_parameters_t *args);
 
@@ -144,7 +144,7 @@ typedef struct _ypObject ypObject;
 // The immortal, null-reference object.
 ypAPI ypObject *const yp_None;
 
-// Increments the reference count of x, returning it as a convenience.  Always succeeds; if x is
+// Increments the reference count of x, returning it as a convenience. Always succeeds; if x is
 // immortal this is a no-op.
 ypAPI ypObject *yp_incref(ypObject *x);
 
@@ -152,7 +152,7 @@ ypAPI ypObject *yp_incref(ypObject *x);
 ypAPI void yp_increfN(int n, ...);
 ypAPI void yp_increfNV(int n, va_list args);
 
-// Decrements the reference count of x, deallocating it if the count reaches zero.  Always
+// Decrements the reference count of x, deallocating it if the count reaches zero. Always
 // succeeds; if x is immortal this is a no-op.
 ypAPI void yp_decref(ypObject *x);
 
@@ -160,7 +160,7 @@ ypAPI void yp_decref(ypObject *x);
 ypAPI void yp_decrefN(int n, ...);
 ypAPI void yp_decrefNV(int n, va_list args);
 
-// Returns true (non-zero) if x is an exception, else false.  Always succeeds.
+// Returns true (non-zero) if x is an exception, else false. Always succeeds.
 ypAPI int yp_isexceptionC(ypObject *x);
 
 
@@ -210,8 +210,8 @@ typedef yp_float64_t yp_float_t;
  * Constructors
  */
 
-// Unlike Python, most nohtyP types have both mutable and immutable versions.  An "intstore" is a
-// mutable int (it "stores" an int); similar for floatstore.  The mutable str is called a
+// Unlike Python, most nohtyP types have both mutable and immutable versions. An "intstore" is a
+// mutable int (it "stores" an int); similar for floatstore. The mutable str is called a
 // "chrarray", while a "frozendict" is an immutable dict.
 
 // Returns a new reference to an int/intstore with the given value.
@@ -219,13 +219,13 @@ ypAPI ypObject *yp_intC(yp_int_t value);
 ypAPI ypObject *yp_intstoreC(yp_int_t value);
 
 // Returns a new reference to an int/intstore with the given str, chrarray, bytes, or bytearray
-// object interpreted as an integer literal in radix base.  The Python-equivalent default for base
+// object interpreted as an integer literal in radix base. The Python-equivalent default for base
 // is 10; a base of 0 means to interpret exactly as a Python code literal.
 ypAPI ypObject *yp_int_baseC(ypObject *x, yp_int_t base);
 ypAPI ypObject *yp_intstore_baseC(ypObject *x, yp_int_t base);
 
-// Returns a new reference to an int/intstore.  If x is a number, it is converted to an int;
-// floating-point numbers are truncated towards zero.  Otherwise, x must be a str, chrarray, bytes,
+// Returns a new reference to an int/intstore. If x is a number, it is converted to an int;
+// floating-point numbers are truncated towards zero. Otherwise, x must be a str, chrarray, bytes,
 // or bytearray object, and this is equivalent to yp_int_baseC(x, 10).
 ypAPI ypObject *yp_int(ypObject *x);
 ypAPI ypObject *yp_intstore(ypObject *x);
@@ -234,14 +234,14 @@ ypAPI ypObject *yp_intstore(ypObject *x);
 ypAPI ypObject *yp_floatCF(yp_float_t value);
 ypAPI ypObject *yp_floatstoreCF(yp_float_t value);
 
-// Returns a new reference to a float/floatstore.  If x is a number, it is converted to a float.
+// Returns a new reference to a float/floatstore. If x is a number, it is converted to a float.
 // Otherwise, x must be a str, chrarray, bytes, or bytearray object, which will be interpreted as a
-// Python floating-point literal.  In either case, if the resulting value is outside the range of
+// Python floating-point literal. In either case, if the resulting value is outside the range of
 // a float then yp_OverflowError is returned.
 ypAPI ypObject *yp_float(ypObject *x);
 ypAPI ypObject *yp_floatstore(ypObject *x);
 
-// Returns a new reference to an iterator for object x.  It is usually unwise to modify an object
+// Returns a new reference to an iterator for object x. It is usually unwise to modify an object
 // being iterated over.
 ypAPI ypObject *yp_iter(ypObject *x);
 
@@ -258,14 +258,14 @@ ypAPI ypObject *yp_generatorC(yp_generator_decl_t *declaration);
 ypAPI ypObject *yp_rangeC3(yp_int_t start, yp_int_t stop, yp_int_t step);
 ypAPI ypObject *yp_rangeC(yp_int_t stop);
 
-// Returns a new reference to a bytes/bytearray, copying the first len bytes from source.  If
+// Returns a new reference to a bytes/bytearray, copying the first len bytes from source. If
 // source is NULL it is considered as having all null bytes; if len is negative source is
 // considered null terminated (and, therefore, will not contain the null byte).
 //  Ex: pre-allocate a bytearray of length 50: yp_bytearrayC(NULL, 50)
 ypAPI ypObject *yp_bytesC(const yp_uint8_t *source, yp_ssize_t len);
 ypAPI ypObject *yp_bytearrayC(const yp_uint8_t *source, yp_ssize_t len);
 
-// Returns a new reference to a bytes/bytearray encoded from the given str or chrarray object.  The
+// Returns a new reference to a bytes/bytearray encoded from the given str or chrarray object. The
 // Python-equivalent default for encoding is yp_s_utf_8, while for errors it is yp_s_strict.
 ypAPI ypObject *yp_bytes3(ypObject *source, ypObject *encoding, ypObject *errors);
 ypAPI ypObject *yp_bytearray3(ypObject *source, ypObject *encoding, ypObject *errors);
@@ -281,9 +281,9 @@ ypAPI ypObject *yp_bytearray(ypObject *source);
 // Returns a new reference to an empty bytearray. (An empty bytes is exported as yp_bytes_empty.)
 ypAPI ypObject *yp_bytearray0(void);
 
-// Returns a new reference to a str/chrarray decoded from the given bytes.  source and len are as
-// in yp_bytesC.  The Python-equivalent default for encoding is yp_s_utf_8 (compatible with an
-// ascii-encoded source), while for errors it is yp_s_strict.  Equivalent to:
+// Returns a new reference to a str/chrarray decoded from the given bytes. source and len are as
+// in yp_bytesC. The Python-equivalent default for encoding is yp_s_utf_8 (compatible with an
+// ascii-encoded source), while for errors it is yp_s_strict. Equivalent to:
 //  yp_str3(yp_bytesC(source, len), encoding, errors)
 ypAPI ypObject *yp_str_frombytesC4(
         const yp_uint8_t *source, yp_ssize_t len, ypObject *encoding, ypObject *errors);
@@ -296,13 +296,13 @@ ypAPI ypObject *yp_chrarray_frombytesC4(
 ypAPI ypObject *yp_str_frombytesC2(const yp_uint8_t *source, yp_ssize_t len);
 ypAPI ypObject *yp_chrarray_frombytesC2(const yp_uint8_t *source, yp_ssize_t len);
 
-// Returns a new reference to a str/chrarray decoded from the given bytes or bytearray object.  The
+// Returns a new reference to a str/chrarray decoded from the given bytes or bytearray object. The
 // Python-equivalent default for encoding is yp_s_utf_8, while for errors it is yp_s_strict.
 ypAPI ypObject *yp_str3(ypObject *source, ypObject *encoding, ypObject *errors);
 ypAPI ypObject *yp_chrarray3(ypObject *source, ypObject *encoding, ypObject *errors);
 
 // Returns a new reference to the "informal" or nicely-printable string representation of object,
-// as a str/chrarray.  As in Python, passing a bytes object to this constructor returns the string
+// as a str/chrarray. As in Python, passing a bytes object to this constructor returns the string
 // representation ("b'Zoot!'"); to decode the bytes, use yp_str3.
 ypAPI ypObject *yp_str(ypObject *object);
 ypAPI ypObject *yp_chrarray(ypObject *object);
@@ -321,7 +321,7 @@ ypAPI ypObject *yp_listN(int n, ...);
 ypAPI ypObject *yp_listNV(int n, va_list args);
 
 // Returns a new reference to a tuple/list made from factor shallow-copies of yp_tupleN(n, ...)
-// concatenated; the length will be factor*n.  Equivalent to "factor * (obj0, obj1, ...)" in
+// concatenated; the length will be factor*n. Equivalent to "factor * (obj0, obj1, ...)" in
 // Python.
 //  Ex: pre-allocate a list of length 99: yp_list_repeatCN(99, 1, yp_None)
 //  Ex: an 8-tuple containing alternating bools: yp_tuple_repeatCN(4, 2, yp_False, yp_True)
@@ -334,9 +334,9 @@ ypAPI ypObject *yp_list_repeatCNV(yp_ssize_t factor, int n, va_list args);
 ypAPI ypObject *yp_tuple(ypObject *iterable);
 ypAPI ypObject *yp_list(ypObject *iterable);
 
-// Returns a new reference to a sorted list from the items in iterable.  key is a one-argument
+// Returns a new reference to a sorted list from the items in iterable. key is a one-argument
 // function used to extract a comparison key from each element in iterable; to compare the elements
-// directly, use yp_None.  If reverse is true, the list elements are sorted as if each comparison
+// directly, use yp_None. If reverse is true, the list elements are sorted as if each comparison
 // were reversed.
 ypAPI ypObject *yp_sorted3(ypObject *iterable, ypObject *key, ypObject *reverse);
 
@@ -364,8 +364,8 @@ ypAPI ypObject *yp_dictK(int n, ...);
 ypAPI ypObject *yp_dictKV(int n, va_list args);
 
 // Returns a new reference to a frozendict/dict containing the given n keys all set to value; the
-// length will be n, unless there are duplicate keys.  The Python-equivalent default of value is
-// yp_None.  Note that, unlike Python, value is the _first_ argument.
+// length will be n, unless there are duplicate keys. The Python-equivalent default of value is
+// yp_None. Note that, unlike Python, value is the _first_ argument.
 //  Ex: pre-allocate a dict with 3 keys: yp_dict_fromkeysN(yp_None, 3, key0, key1, key2)
 ypAPI ypObject *yp_frozendict_fromkeysN(ypObject *value, int n, ...);
 ypAPI ypObject *yp_frozendict_fromkeysNV(ypObject *value, int n, va_list args);
@@ -377,9 +377,9 @@ ypAPI ypObject *yp_dict_fromkeysNV(ypObject *value, int n, va_list args);
 ypAPI ypObject *yp_frozendict_fromkeys(ypObject *iterable, ypObject *value);
 ypAPI ypObject *yp_dict_fromkeys(ypObject *iterable, ypObject *value);
 
-// Returns a new reference to a frozendict/dict whose key-value pairs come from x.  x can be a
+// Returns a new reference to a frozendict/dict whose key-value pairs come from x. x can be a
 // mapping object (that supports yp_iter_items), or an iterable that yields exactly two items at a
-// time (ie (key, value)).  If a given key is seen more than once, the last value yielded is
+// time (ie (key, value)). If a given key is seen more than once, the last value yielded is
 // retained.
 ypAPI ypObject *yp_frozendict(ypObject *x);
 ypAPI ypObject *yp_dict(ypObject *x);
@@ -408,37 +408,37 @@ ypAPI ypObject *yp_bool(ypObject *x);
 // Returns the immortal yp_True if x is considered false, otherwise yp_False.
 ypAPI ypObject *yp_not(ypObject *x);
 
-// Returns a *new* reference to y if x is false, otherwise to x.  Unlike Python, both arguments are
-// always evaluated (there is no short-circuiting).  You may find yp_anyN more convenient, as it
+// Returns a *new* reference to y if x is false, otherwise to x. Unlike Python, both arguments are
+// always evaluated (there is no short-circuiting). You may find yp_anyN more convenient, as it
 // returns an immortal.
 ypAPI ypObject *yp_or(ypObject *x, ypObject *y);
 
-// A convenience function to "or" n objects, returning a *new* reference.  Returns yp_False if n is
-// zero, and the first object if n is one.  Unlike Python, all arguments are always evaluated (there
-// is no short-circuiting).  You may find yp_anyN more convenient, as it returns an immortal.
+// A convenience function to "or" n objects, returning a *new* reference. Returns yp_False if n is
+// zero, and the first object if n is one. Unlike Python, all arguments are always evaluated (there
+// is no short-circuiting). You may find yp_anyN more convenient, as it returns an immortal.
 ypAPI ypObject *yp_orN(int n, ...);
 ypAPI ypObject *yp_orNV(int n, va_list args);
 
-// Equivalent to yp_bool(yp_orN(n, ...)).  (Returns an immortal.)
+// Equivalent to yp_bool(yp_orN(n, ...)). (Returns an immortal.)
 ypAPI ypObject *yp_anyN(int n, ...);
 ypAPI ypObject *yp_anyNV(int n, va_list args);
 
 // Returns the immortal yp_True if any element of iterable is true; if the iterable is empty,
-// returns yp_False.  Stops iterating at the first true element.
+// returns yp_False. Stops iterating at the first true element.
 ypAPI ypObject *yp_any(ypObject *iterable);
 
-// Returns a *new* reference to x if x is false, otherwise to y.  Unlike Python, both arguments are
-// always evaluated (there is no short-circuiting).  You may find yp_allN more convenient, as it
+// Returns a *new* reference to x if x is false, otherwise to y. Unlike Python, both arguments are
+// always evaluated (there is no short-circuiting). You may find yp_allN more convenient, as it
 // returns an immortal.
 ypAPI ypObject *yp_and(ypObject *x, ypObject *y);
 
-// A convenience function to "and" n objects, returning a *new* reference.  Returns yp_True if n is
-// zero, and the first object if n is one.  Unlike Python, all arguments are always evaluated (there
-// is no short-circuiting).  You may find yp_allN more convenient, as it returns an immortal.
+// A convenience function to "and" n objects, returning a *new* reference. Returns yp_True if n is
+// zero, and the first object if n is one. Unlike Python, all arguments are always evaluated (there
+// is no short-circuiting). You may find yp_allN more convenient, as it returns an immortal.
 ypAPI ypObject *yp_andN(int n, ...);
 ypAPI ypObject *yp_andNV(int n, va_list args);
 
-// Equivalent to yp_bool(yp_andN(n, ...)).  (Returns an immortal.)
+// Equivalent to yp_bool(yp_andN(n, ...)). (Returns an immortal.)
 ypAPI ypObject *yp_allN(int n, ...);
 ypAPI ypObject *yp_allNV(int n, va_list args);
 
@@ -447,7 +447,7 @@ ypAPI ypObject *yp_allNV(int n, va_list args);
 ypAPI ypObject *yp_all(ypObject *iterable);
 
 // Implements the "less than" (x<y), "less than or equal" (x<=y), "equal" (x==y), "not equal"
-// (x!=y), "greater than or equal" (x>=y), and "greater than" (x>y) comparisons.  Returns the
+// (x!=y), "greater than or equal" (x>=y), and "greater than" (x>y) comparisons. Returns the
 // immortal yp_True if the condition is true, otherwise yp_False.
 ypAPI ypObject *yp_lt(ypObject *x, ypObject *y);
 ypAPI ypObject *yp_le(ypObject *x, ypObject *y);
@@ -463,12 +463,12 @@ ypAPI ypObject *yp_gt(ypObject *x, ypObject *y);
  * Generic Object Operations
  */
 
-// Returns the hash value of x; x must be immutable and must not contain mutable objects.  Returns
+// Returns the hash value of x; x must be immutable and must not contain mutable objects. Returns
 // -1 and sets *exc on error.
 ypAPI yp_hash_t yp_hashC(ypObject *x, ypObject **exc);
 
 // Returns the _current_ hash value of x; this value may change between calls. Returns -1 and sets
-// *exc on error.  This is able to calculate the hash value of mutable objects and objects
+// *exc on error. This is able to calculate the hash value of mutable objects and objects
 // containing mutable objects that would otherwise fail with yp_hashC.
 ypAPI yp_hash_t yp_currenthashC(ypObject *x, ypObject **exc);
 
@@ -478,17 +478,17 @@ ypAPI yp_hash_t yp_currenthashC(ypObject *x, ypObject **exc);
  */
 
 // An "iterator" is an object that implements yp_next, while an "iterable" is an object that
-// implements yp_iter.  Examples of iterables include range, bytes, str, tuple, set, and dict;
-// examples of iterators include files and generators.  It is usually unwise to modify an object
+// implements yp_iter. Examples of iterables include range, bytes, str, tuple, set, and dict;
+// examples of iterators include files and generators. It is usually unwise to modify an object
 // being iterated over.
 
 // "Sends" a value into *iterator and returns a new reference to the next yielded value, or an
-// exception.  The value may be ignored by the iterator.  value cannot be an exception.  When the
+// exception. The value may be ignored by the iterator. value cannot be an exception. When the
 // iterator is exhausted yp_StopIteration is returned; on any other error, *iterator is discarded
 // and set to an exception, _and_ an exception is returned.
 ypAPI ypObject *yp_send(ypObject **iterator, ypObject *value);
 
-// Equivalent to yp_send(iterator, yp_None).  Typically used on iterators that ignore the value.
+// Equivalent to yp_send(iterator, yp_None). Typically used on iterators that ignore the value.
 ypAPI ypObject *yp_next(ypObject **iterator);
 
 // Similar to yp_next, but when the iterator is exhausted a new reference to defval is returned.
@@ -497,26 +497,26 @@ ypAPI ypObject *yp_next(ypObject **iterator);
 ypAPI ypObject *yp_next2(ypObject **iterator, ypObject *defval);
 
 // "Sends" an exception into *iterator and returns a new reference to the next yielded value, or an
-// exception.  The iterator may ignore exc, or it may return it or any other exception.  If exc is
-// not an exception, yp_TypeError is raised.  When the iterator is exhausted yp_StopIteration is
+// exception. The iterator may ignore exc, or it may return it or any other exception. If exc is
+// not an exception, yp_TypeError is raised. When the iterator is exhausted yp_StopIteration is
 // returned; on any other error, *iterator is discarded and set to an exception, _and_ an exception
 // is returned.
 ypAPI ypObject *yp_throw(ypObject **iterator, ypObject *exc);
 
-// Returns a hint as to how many items are left to be yielded.  The accuracy of this hint depends
+// Returns a hint as to how many items are left to be yielded. The accuracy of this hint depends
 // on the underlying type: most containers know their lengths exactly, but some generators may not.
 // A hint of zero could mean that the iterator is exhausted, that the length is unknown, or that
-// the iterator will yield infinite values.  Returns zero and sets *exc on error.
+// the iterator will yield infinite values. Returns zero and sets *exc on error.
 ypAPI yp_ssize_t yp_length_hintC(ypObject *iterator, ypObject **exc);
 
-// "Closes" the iterator by calling yp_throw(iterator, yp_GeneratorExit).  If yp_StopIteration or
+// "Closes" the iterator by calling yp_throw(iterator, yp_GeneratorExit). If yp_StopIteration or
 // yp_GeneratorExit is returned by yp_throw, *iterator is not discarded; on any other error,
-// *iterator is discarded and set to an exception.  The behaviour of this method for other
+// *iterator is discarded and set to an exception. The behaviour of this method for other
 // types, in particular files, is documented elsewhere.
 ypAPI void yp_close(ypObject **iterator);
 
-// Sets the given n ypObject**s to new references for the values yielded from iterable.  Iterable
-// must yield exactly n objects, or else a yp_ValueError is raised.  Sets all n ypObject**s to the
+// Sets the given n ypObject**s to new references for the values yielded from iterable. Iterable
+// must yield exactly n objects, or else a yp_ValueError is raised. Sets all n ypObject**s to the
 // same exception on error.
 ypAPI void yp_unpackN(ypObject *iterable, int n, ...);
 ypAPI void yp_unpackNV(ypObject *iterable, int n, va_list args);
@@ -528,7 +528,7 @@ ypAPI ypObject *yp_filter(ypObject *function, ypObject *iterable);
 // Similar to yp_filter, but yields values for which function returns false.
 ypAPI ypObject *yp_filterfalse(ypObject *function, ypObject *iterable);
 
-// Returns a new reference to the largest/smallest of the given n objects.  key is a one-argument
+// Returns a new reference to the largest/smallest of the given n objects. key is a one-argument
 // function used to extract a comparison key from each element in iterable; to compare the elements
 // directly, use yp_None.
 ypAPI ypObject *yp_max_keyN(ypObject *key, int n, ...);
@@ -542,7 +542,7 @@ ypAPI ypObject *yp_maxNV(int n, va_list args);
 ypAPI ypObject *yp_minN(int n, ...);
 ypAPI ypObject *yp_minNV(int n, va_list args);
 
-// Returns a new reference to the largest/smallest element in iterable.  key is as in yp_max_keyN.
+// Returns a new reference to the largest/smallest element in iterable. key is as in yp_max_keyN.
 ypAPI ypObject *yp_max_key(ypObject *iterable, ypObject *key);
 ypAPI ypObject *yp_min_key(ypObject *iterable, ypObject *key);
 
@@ -595,19 +595,19 @@ ypAPI ypObject *yp_in(ypObject *x, ypObject *container);
 // Returns the immortal yp_False if an item of container is equal to x, else yp_True.
 ypAPI ypObject *yp_not_in(ypObject *x, ypObject *container);
 
-// Returns the length of container.  Returns zero and sets *exc on error.
+// Returns the length of container. Returns zero and sets *exc on error.
 ypAPI yp_ssize_t yp_lenC(ypObject *container, ypObject **exc);
 
-// Adds an item to *container.  On error, *container is discarded and set to an exception.  The
+// Adds an item to *container. On error, *container is discarded and set to an exception. The
 // relation between yp_push and yp_pop depends on the type: x may be the first or last item popped,
 // or items may be popped in arbitrary order.
 ypAPI void yp_push(ypObject **container, ypObject *x);
 
-// Removes all items from *container.  On error, *container is discarded and set to an exception.
+// Removes all items from *container. On error, *container is discarded and set to an exception.
 ypAPI void yp_clear(ypObject **container);
 
-// Removes an item from *container and returns a new reference to it.  On error, *container is
-// discarded and set to an exception _and_ an exception is returned.  (Not supported on dicts; use
+// Removes an item from *container and returns a new reference to it. On error, *container is
+// discarded and set to an exception _and_ an exception is returned. (Not supported on dicts; use
 // yp_popvalue3 or yp_popitem instead.)
 ypAPI ypObject *yp_pop(ypObject **container);
 
@@ -617,16 +617,16 @@ ypAPI ypObject *yp_pop(ypObject **container);
  */
 
 // These methods are supported by bytes, str, and tuple (and their mutable counterparts, of
-// course).  Most methods are also supported by range; notable exceptions are yp_concat and
-// yp_repeatC.  They are _not_ supported by frozenset and frozendict because those types do not
+// course). Most methods are also supported by range; notable exceptions are yp_concat and
+// yp_repeatC. They are _not_ supported by frozenset and frozendict because those types do not
 // store their elements in any particular order.
 
-// Sequences are indexed origin zero.  Negative indices are relative to the end of the sequence: in
-// effect, when i is negative it is substituted with len(s)+i, and len(s)+j for negative j.  The
+// Sequences are indexed origin zero. Negative indices are relative to the end of the sequence: in
+// effect, when i is negative it is substituted with len(s)+i, and len(s)+j for negative j. The
 // slice of s from i to j with step k is the sequence of items with indices i, i+k, i+2*k, i+3*k
-// and so on, stopping when j is reached (but never including j); k cannot be zero.  A single index
+// and so on, stopping when j is reached (but never including j); k cannot be zero. A single index
 // outside of range(-len(s),len(s)) raises a yp_IndexError, but in a slice such an index gets
-// clamped to the bounds of the sequence.  See yp_SLICE_DEFAULT and yp_SLICE_USELEN below for more
+// clamped to the bounds of the sequence. See yp_SLICE_DEFAULT and yp_SLICE_USELEN below for more
 // information.
 
 // Returns a new reference to the concatenation of sequence and x.
@@ -638,7 +638,7 @@ ypAPI ypObject *yp_repeatC(ypObject *sequence, yp_ssize_t factor);
 // Returns a new reference to the i-th item of sequence.
 ypAPI ypObject *yp_getindexC(ypObject *sequence, yp_ssize_t i);
 
-// Returns a new reference to the slice of sequence from i to j with step k.  The Python-equivalent
+// Returns a new reference to the slice of sequence from i to j with step k. The Python-equivalent
 // "defaults" for i and j are yp_SLICE_DEFAULT, while for k it is 1.
 ypAPI ypObject *yp_getsliceC4(ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k);
 
@@ -646,8 +646,8 @@ ypAPI ypObject *yp_getsliceC4(ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp
 ypAPI ypObject *yp_getitem(ypObject *sequence, ypObject *key);
 
 // Returns the lowest index in sequence where x is found, such that x is contained in the slice
-// sequence[i:j], or -1 if x is not found.  Returns -1 and sets *exc on error; *exc is _not_ set
-// if x is simply not found.  Types such as tuples inspect only one item at a time, while types
+// sequence[i:j], or -1 if x is not found. Returns -1 and sets *exc on error; *exc is _not_ set
+// if x is simply not found. Types such as tuples inspect only one item at a time, while types
 // such as strs look for a particular sub-sequence of items.
 ypAPI yp_ssize_t yp_findC4(
         ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j, ypObject **exc);
@@ -669,8 +669,8 @@ ypAPI yp_ssize_t yp_rindexC4(
         ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j, ypObject **exc);
 ypAPI yp_ssize_t yp_rindexC(ypObject *sequence, ypObject *x, ypObject **exc);
 
-// Returns the total number of non-overlapping occurrences of x in sequence[i:j].  Returns 0 and
-// sets *exc on error.  Types such as tuples inspect only one item at a time, while types such as
+// Returns the total number of non-overlapping occurrences of x in sequence[i:j]. Returns 0 and
+// sets *exc on error. Types such as tuples inspect only one item at a time, while types such as
 // strs look for a particular sub-sequence of items.
 ypAPI yp_ssize_t yp_countC4(
         ypObject *sequence, ypObject *x, yp_ssize_t i, yp_ssize_t j, ypObject **exc);
@@ -678,11 +678,11 @@ ypAPI yp_ssize_t yp_countC4(
 // Equivalent to yp_countC4(sequence, x, 0, yp_SLICE_USELEN, exc).
 ypAPI yp_ssize_t yp_countC(ypObject *sequence, ypObject *x, ypObject **exc);
 
-// Sets the i-th item of *sequence to x.  On error, *sequence is discarded and set to an exception.
+// Sets the i-th item of *sequence to x. On error, *sequence is discarded and set to an exception.
 ypAPI void yp_setindexC(ypObject **sequence, yp_ssize_t i, ypObject *x);
 
-// Sets the slice of *sequence, from i to j with step k, to x.  The Python-equivalent "defaults"
-// for i and j are yp_SLICE_DEFAULT, while for k it is 1.  On error, *sequence is discarded and
+// Sets the slice of *sequence, from i to j with step k, to x. The Python-equivalent "defaults"
+// for i and j are yp_SLICE_DEFAULT, while for k it is 1. On error, *sequence is discarded and
 // set to an exception.
 ypAPI void yp_setsliceC5(
         ypObject **sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject *x);
@@ -690,27 +690,27 @@ ypAPI void yp_setsliceC5(
 // Equivalent to yp_setindexC(sequence, yp_asssizeC(key, &exc), x).
 ypAPI void yp_setitem(ypObject **sequence, ypObject *key, ypObject *x);
 
-// Removes the i-th item from *sequence.  On error, *sequence is discarded and set to an exception.
+// Removes the i-th item from *sequence. On error, *sequence is discarded and set to an exception.
 ypAPI void yp_delindexC(ypObject **sequence, yp_ssize_t i);
 
-// Removes the elements of the slice from *sequence, from i to j with step k.  The Python-
-// equivalent "defaults" for i and j are yp_SLICE_DEFAULT, while for k it is 1.  On error,
+// Removes the elements of the slice from *sequence, from i to j with step k. The Python-
+// equivalent "defaults" for i and j are yp_SLICE_DEFAULT, while for k it is 1. On error,
 // *sequence is discarded and set to an exception.
 ypAPI void yp_delsliceC4(ypObject **sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k);
 
 // Equivalent to yp_delindexC(sequence, yp_asssizeC(key, &exc)).
 ypAPI void yp_delitem(ypObject **sequence, ypObject *key);
 
-// Appends x to the end of *sequence.  On error, *sequence is discarded and set to an exception.
+// Appends x to the end of *sequence. On error, *sequence is discarded and set to an exception.
 ypAPI void yp_append(ypObject **sequence, ypObject *x);
 ypAPI void yp_push(ypObject **sequence, ypObject *x);
 
-// Appends the contents of t to the end of *sequence.  On error, *sequence is discarded and set to
+// Appends the contents of t to the end of *sequence. On error, *sequence is discarded and set to
 // an exception.
 ypAPI void yp_extend(ypObject **sequence, ypObject *t);
 
 // Appends the contents of *sequence to itself factor-1 times; if factor is zero *sequence is
-// cleared.  Equivalent to seq*=factor for lists in Python.  On error, *sequence is discarded and
+// cleared. Equivalent to seq*=factor for lists in Python. On error, *sequence is discarded and
 // set to an exception.
 ypAPI void yp_irepeatC(ypObject **sequence, yp_ssize_t factor);
 
@@ -718,29 +718,29 @@ ypAPI void yp_irepeatC(ypObject **sequence, yp_ssize_t factor);
 // On error, *sequence is discarded and set to an exception.
 ypAPI void yp_insertC(ypObject **sequence, yp_ssize_t i, ypObject *x);
 
-// Removes the i-th item from *sequence and returns it.  The Python-equivalent "default" for i is
-// -1.  On error, *sequence is discarded and set to an exception _and_ an exception is returned.
+// Removes the i-th item from *sequence and returns it. The Python-equivalent "default" for i is
+// -1. On error, *sequence is discarded and set to an exception _and_ an exception is returned.
 ypAPI ypObject *yp_popindexC(ypObject **sequence, yp_ssize_t i);
 
-// Equivalent to yp_popindexC(sequence, -1).  Note that for sequences, yp_push and yp_pop
+// Equivalent to yp_popindexC(sequence, -1). Note that for sequences, yp_push and yp_pop
 // together implement a stack (last in, first out).
 ypAPI ypObject *yp_pop(ypObject **sequence);
 
-// Removes the first item from *sequence that equals x.  Raises yp_ValueError if x is not
-// contained in *sequence.  On error, *sequence is discarded and set to an exception.
+// Removes the first item from *sequence that equals x. Raises yp_ValueError if x is not
+// contained in *sequence. On error, *sequence is discarded and set to an exception.
 ypAPI void yp_remove(ypObject **sequence, ypObject *x);
 
-// Removes the first item from *sequence that equals x.  Does _not_ raise an exception if x is not
-// contained in *sequence.  On error, *sequence is discarded and set to an exception.
+// Removes the first item from *sequence that equals x. Does _not_ raise an exception if x is not
+// contained in *sequence. On error, *sequence is discarded and set to an exception.
 ypAPI void yp_discard(ypObject **sequence, ypObject *x);
 
-// Reverses the items of *sequence in-place.  On error, *sequence is discarded and set to an
+// Reverses the items of *sequence in-place. On error, *sequence is discarded and set to an
 // exception.
 ypAPI void yp_reverse(ypObject **sequence);
 
-// Sorts the items of *sequence in-place.  key is a one-argument function used to extract a
-// comparison key from each element in iterable; to compare the elements directly, use yp_None.  If
-// reverse is true, the list elements are sorted as if each comparison were reversed.  On error,
+// Sorts the items of *sequence in-place. key is a one-argument function used to extract a
+// comparison key from each element in iterable; to compare the elements directly, use yp_None. If
+// reverse is true, the list elements are sorted as if each comparison were reversed. On error,
 // *sequence is discarded and set to an exception.
 ypAPI void yp_sort3(ypObject **sequence, ypObject *key, ypObject *reverse);
 
@@ -748,20 +748,20 @@ ypAPI void yp_sort3(ypObject **sequence, ypObject *key, ypObject *reverse);
 ypAPI void yp_sort(ypObject **sequence);
 
 // When given to a slice-like start/stop C argument, signals that the default "end" value be
-// substituted for the argument.  Which end depends on the sign of step:
+// substituted for the argument. Which end depends on the sign of step:
 //  - positive step: 0 substituted for start, len(s) substituted for stop
 //  - negative step: len(s)-1 substituted for start, -1 substituted for stop
 //  Ex: The nohtyP equivalent of "[::a]" is "yp_SLICE_DEFAULT, yp_SLICE_DEFAULT, a"
 #define yp_SLICE_DEFAULT yp_SSIZE_T_MIN
 
 // When given to a slice-like start/stop C argument, signals that len(s) should be substituted for
-// the argument.  In other words, it signals that the slice should start/stop at the end of the
+// the argument. In other words, it signals that the slice should start/stop at the end of the
 // sequence.
 //  Ex: The nohtyP equivalent of "[:]" is "0, yp_SLICE_USELEN, 1"
 #define yp_SLICE_USELEN yp_SSIZE_T_MAX
 
 // When an index in a slice is outside of range(-len(s),len(s)), it gets clamped to the bounds of
-// the sequence.  Specifically:
+// the sequence. Specifically:
 //  - if i>=len(s) and k>0, or i<-len(s) and k<0, the slice is empty, regardless of j
 //  - if i>=len(s) and k<0, the (reversed) slice starts with the last element
 //  - if i<-len(s) and k>0, the slice starts with the first element
@@ -814,45 +814,45 @@ ypAPI ypObject *yp_differenceNV(ypObject *set, int n, va_list args);
 // either set or x but not both.
 ypAPI ypObject *yp_symmetric_difference(ypObject *set, ypObject *x);
 
-// Add the elements from the n objects to *set.  On error, *set is discarded and set to an
+// Add the elements from the n objects to *set. On error, *set is discarded and set to an
 // exception.
 ypAPI void yp_updateN(ypObject **set, int n, ...);
 ypAPI void yp_updateNV(ypObject **set, int n, va_list args);
 
-// Removes elements from *set that are not contained in all n objects.  On error, *set is discarded
+// Removes elements from *set that are not contained in all n objects. On error, *set is discarded
 // and set to an exception.
 ypAPI void yp_intersection_updateN(ypObject **set, int n, ...);
 ypAPI void yp_intersection_updateNV(ypObject **set, int n, va_list args);
 
-// Removes elements from *set that are contained in any of the n objects.  On error, *set is
+// Removes elements from *set that are contained in any of the n objects. On error, *set is
 // discarded and set to an exception.
 ypAPI void yp_difference_updateN(ypObject **set, int n, ...);
 ypAPI void yp_difference_updateNV(ypObject **set, int n, va_list args);
 
 // Removes elements from *set that are contained in x, and adds elements from x not contained in
-// *set.  On error, *set is discarded and set to an exception.
+// *set. On error, *set is discarded and set to an exception.
 ypAPI void yp_symmetric_difference_update(ypObject **set, ypObject *x);
 
-// Adds element x to *set.  On error, *set is discarded and set to an exception.  While Python
+// Adds element x to *set. On error, *set is discarded and set to an exception. While Python
 // calls this method add, yp_add is already used for "a+b", so these two equivalent aliases are
 // provided instead.
 ypAPI void yp_push(ypObject **set, ypObject *x);
 ypAPI void yp_set_add(ypObject **set, ypObject *x);
 
-// If x is already contained in set, raises yp_KeyError; otherwise, adds x to set.  Sets *exc
+// If x is already contained in set, raises yp_KeyError; otherwise, adds x to set. Sets *exc
 // on error (set is never discarded).
 ypAPI void yp_pushuniqueE(ypObject *set, ypObject *x, ypObject **exc);
 
-// Removes element x from *set.  Raises yp_KeyError if x is not contained in *set.  On error,
+// Removes element x from *set. Raises yp_KeyError if x is not contained in *set. On error,
 // *set is discarded and set to an exception.
 ypAPI void yp_remove(ypObject **set, ypObject *x);
 
-// Removes element x from *set.  Does _not_ raise an exception if x is not contained in *set.  On
+// Removes element x from *set. Does _not_ raise an exception if x is not contained in *set. On
 // error, *set is discarded and set to an exception.
 ypAPI void yp_discard(ypObject **set, ypObject *x);
 
-// Removes an arbitrary item from *set and returns a new reference to it.  On error, *set is
-// discarded and set to an exception _and_ an exception is returned.  You cannot use the order
+// Removes an arbitrary item from *set and returns a new reference to it. On error, *set is
+// discarded and set to an exception _and_ an exception is returned. You cannot use the order
 // of yp_push calls on sets to determine the order of yp_pop'ped elements.
 ypAPI ypObject *yp_pop(ypObject **set);
 
@@ -864,14 +864,14 @@ ypAPI ypObject *const yp_frozenset_empty;
  * Mapping Operations
  */
 
-// frozendicts and dicts are both mapping objects.  Note that yp_contains, yp_in, yp_not_in,
+// frozendicts and dicts are both mapping objects. Note that yp_contains, yp_in, yp_not_in,
 // and yp_iter operate solely on a mapping's keys.
 
-// Returns a new reference to the value of mapping with the given key.  Returns yp_KeyError if key
+// Returns a new reference to the value of mapping with the given key. Returns yp_KeyError if key
 // is not in the map.
 ypAPI ypObject *yp_getitem(ypObject *mapping, ypObject *key);
 
-// Similar to yp_getitem, but returns a new reference to defval if key is not in the map.  defval
+// Similar to yp_getitem, but returns a new reference to defval if key is not in the map. defval
 // _can_ be an exception; the Python-equivalent "default" for defval is yp_None.
 ypAPI ypObject *yp_getdefault(ypObject *mapping, ypObject *key, ypObject *defval);
 
@@ -884,42 +884,42 @@ ypAPI ypObject *yp_iter_keys(ypObject *mapping);
 // Returns a new reference to an iterator that yields mapping's values.
 ypAPI ypObject *yp_iter_values(ypObject *mapping);
 
-// Adds or replaces the value of *mapping with the given key, setting it to x.  On error, *mapping
+// Adds or replaces the value of *mapping with the given key, setting it to x. On error, *mapping
 // is discarded and set to an exception.
 ypAPI void yp_setitem(ypObject **mapping, ypObject *key, ypObject *x);
 
-// Removes the item with the given key from *mapping.  Raises yp_KeyError if key is not in
-// *mapping.  On error, *mapping is discarded and set to an exception.
+// Removes the item with the given key from *mapping. Raises yp_KeyError if key is not in
+// *mapping. On error, *mapping is discarded and set to an exception.
 ypAPI void yp_delitem(ypObject **mapping, ypObject *key);
 
 // If key is in mapping, remove it and return a new reference to its value, else return a new
-// reference to defval.  defval _can_ be an exception: if it is, then a missing key is treated as
-// an error (including discarding *mapping).  The Python-equivalent "default" of defval is
-// yp_KeyError.  On error, *mapping is discarded and set to an exception _and_ that exception is
-// returned.  Note that yp_push and yp_pop are not applicable for mapping objects.
+// reference to defval. defval _can_ be an exception: if it is, then a missing key is treated as
+// an error (including discarding *mapping). The Python-equivalent "default" of defval is
+// yp_KeyError. On error, *mapping is discarded and set to an exception _and_ that exception is
+// returned. Note that yp_push and yp_pop are not applicable for mapping objects.
 ypAPI ypObject *yp_popvalue3(ypObject **mapping, ypObject *key, ypObject *defval);
 
 // Equivalent to yp_popvalue3(mapping, key, yp_KeyError).
 ypAPI ypObject *yp_popvalue2(ypObject **mapping, ypObject *key);
 
-// Removes an arbitrary item from *mapping and returns new references to its *key and *value.  If
-// mapping is empty yp_KeyError is raised.  On error, *mapping is discarded and set to an exception
+// Removes an arbitrary item from *mapping and returns new references to its *key and *value. If
+// mapping is empty yp_KeyError is raised. On error, *mapping is discarded and set to an exception
 // _and_ both *key and *value are set to exceptions.
 ypAPI void yp_popitem(ypObject **mapping, ypObject **key, ypObject **value);
 
 // Similar to yp_getitem, but returns a new reference to defval _and_ adds it to *mapping if key is
-// not in the map.  defval cannot be an exception.  The Python-equivalent "default" for defval is
-// yp_None.  On error, *mapping is discarded and set to an exception _and_ an exception is
+// not in the map. defval cannot be an exception. The Python-equivalent "default" for defval is
+// yp_None. On error, *mapping is discarded and set to an exception _and_ an exception is
 // returned.
 ypAPI ypObject *yp_setdefault(ypObject **mapping, ypObject *key, ypObject *defval);
 
 // Add the given n key/value pairs (for a total of 2*n objects) to *mapping, overwriting existing
-// keys.  If a given key is seen more than once, the last value is retained.  On error, *mapping is
+// keys. If a given key is seen more than once, the last value is retained. On error, *mapping is
 // discarded and set to an exception.
 ypAPI void yp_updateK(ypObject **mapping, int n, ...);
 ypAPI void yp_updateKV(ypObject **mapping, int n, va_list args);
 
-// Add the elements from the n objects to *mapping.  Each object is handled as per yp_dict.  On
+// Add the elements from the n objects to *mapping. Each object is handled as per yp_dict. On
 // error, *mapping is discarded and set to an exception.
 ypAPI void yp_updateN(ypObject **mapping, int n, ...);
 ypAPI void yp_updateNV(ypObject **mapping, int n, va_list args);
@@ -934,8 +934,8 @@ ypAPI ypObject *const yp_frozendict_empty;
 
 // These methods are supported by bytes and str (and their mutable counterparts, of course).
 // Individual elements of bytes and bytearrays are ints, so yp_getindexC will always return ints
-// for these types, and will only accept ints for yp_setindexC.  The individual elements of strs and
-// chrarrays are single-character strs.  Using bytes/bytearray arguments on a str/chrarray method,
+// for these types, and will only accept ints for yp_setindexC. The individual elements of strs and
+// chrarrays are single-character strs. Using bytes/bytearray arguments on a str/chrarray method,
 // or str/chrarray arguments on a bytes/bytearray method, raises yp_TypeError (unless otherwise
 // documented).
 
@@ -943,7 +943,7 @@ ypAPI ypObject *const yp_frozendict_empty;
 // will return a bytearray, while a slice of a str is another str, and so forth.
 
 // Unlike Python, the arguments start/end (yp_startswithC4 et al) and i/j (yp_findC4 et al) are
-// always treated as in slice notation.  Python behaves peculiarly when end<start in certain edge
+// always treated as in slice notation. Python behaves peculiarly when end<start in certain edge
 // cases involving empty strings (compare "foo"[5:0].startswith("") to "foo".startswith("", 5, 0)).
 
 // Immortal strs representing common encodings, for convience with yp_str_frombytesC4 et al.
@@ -970,22 +970,22 @@ ypAPI ypObject *const yp_s_surrogateescape;    // "surrogateescape"
 ypAPI ypObject *const yp_s_surrogatepass;      // "surrogatepass"
 
 // Returns the immortal yp_True if all characters in s are alphanumeric and there is at least one
-// character, otherwise yp_False.  A character is alphanumeric if one of the following returns
+// character, otherwise yp_False. A character is alphanumeric if one of the following returns
 // yp_True: yp_isalpha, yp_isdecimal, yp_isdigit, or yp_isnumeric.
 ypAPI ypObject *yp_isalnum(ypObject *s);
 
 // Returns the immortal yp_True if all characters in s are alphabetic and there is at least one
-// character, otherwise yp_False.  Alphabetic characters are those characters defined in the
-// Unicode character database as "Letter".  Note that this is different from the "Alphabetic"
+// character, otherwise yp_False. Alphabetic characters are those characters defined in the
+// Unicode character database as "Letter". Note that this is different from the "Alphabetic"
 // property defined in the Unicode Standard.
 ypAPI ypObject *yp_isalpha(ypObject *s);
 
 // Returns the immortal yp_True if all characters in s are decimal characters and there is at least
-// one character, otherwise yp_False.  Decimal characters are those from general category "Nd".
+// one character, otherwise yp_False. Decimal characters are those from general category "Nd".
 ypAPI ypObject *yp_isdecimal(ypObject *s);
 
 // Returns the immortal yp_True if all characters in s are digits and there is at least one
-// character, otherwise yp_False.  Digit characters are those that have the property value
+// character, otherwise yp_False. Digit characters are those that have the property value
 // Numeric_Type=Digit or Numeric_Type=Decimal.
 ypAPI ypObject *yp_isdigit(ypObject *s);
 
@@ -994,34 +994,34 @@ ypAPI ypObject *yp_isdigit(ypObject *s);
 ypAPI ypObject *yp_isidentifier(ypObject *s);
 
 // Returns the immortal yp_True if all cased characters in s are lowercase and there is at least
-// one cased character, otherwise yp_False.  Cased characters are those with a general category
+// one cased character, otherwise yp_False. Cased characters are those with a general category
 // property of "Lu", "Ll", or "Lt".
 ypAPI ypObject *yp_islower(ypObject *s);
 
 // Returns the immortal yp_True if all characters in s are numeric characters and there is at
-// least one character, otherwise yp_False.  Numeric characters are those that have the Unicode
+// least one character, otherwise yp_False. Numeric characters are those that have the Unicode
 // numeric value property.
 ypAPI ypObject *yp_isnumeric(ypObject *s);
 
 // Returns the immortal yp_True if all characters in s are printable or s is empty, otherwise
-// yp_False.  Nonprintable characters are those characters defined in the Unicode character
+// yp_False. Nonprintable characters are those characters defined in the Unicode character
 // database as "Other" or "Separator", excepting space (0x20) which is considered printable.
 ypAPI ypObject *yp_isprintable(ypObject *s);
 
 // Returns the immortal yp_True if there are only whitespace characters in s and there is at least
-// one character, otherwise yp_False.  Whitespace characters are those characters defined in the
+// one character, otherwise yp_False. Whitespace characters are those characters defined in the
 // Unicode character database as "Other" or "Separator" and those with bidirectional property
 // being one of "WS", "B", or "S".
 ypAPI ypObject *yp_isspace(ypObject *s);
 
 // Returns the immortal yp_True if all cased characters in s are uppercase and there is at least
-// one cased character, otherwise yp_False.  Cased characters are those with a general category
+// one cased character, otherwise yp_False. Cased characters are those with a general category
 // property of "Lu", "Ll", or "Lt".
 ypAPI ypObject *yp_isupper(ypObject *s);
 
 // Returns the immortal yp_True if s[start:end] starts with the specified prefix, otherwise
-// yp_False.  prefix can also be a tuple of prefix strings for which to look.  If a prefix string
-// is empty, returns yp_True.  yp_startswith considers the entire string (as if start is 0 and end
+// yp_False. prefix can also be a tuple of prefix strings for which to look. If a prefix string
+// is empty, returns yp_True. yp_startswith considers the entire string (as if start is 0 and end
 // is yp_SLICE_USELEN).
 ypAPI ypObject *yp_startswithC4(ypObject *s, ypObject *prefix, yp_ssize_t start, yp_ssize_t end);
 ypAPI ypObject *yp_startswith(ypObject *s, ypObject *prefix);
@@ -1030,15 +1030,15 @@ ypAPI ypObject *yp_startswith(ypObject *s, ypObject *prefix);
 ypAPI ypObject *yp_endswithC4(ypObject *s, ypObject *suffix, yp_ssize_t start, yp_ssize_t end);
 ypAPI ypObject *yp_endswith(ypObject *s, ypObject *suffix);
 
-// Returns a new reference to a lowercased copy of s.  The lowercasing algorithm is described in
+// Returns a new reference to a lowercased copy of s. The lowercasing algorithm is described in
 // section 3.13 of the Unicode Standard.
 ypAPI ypObject *yp_lower(ypObject *s);
 
-// Returns a new reference to an uppercased copy of s.  The uppercasing algorithm is described in
+// Returns a new reference to an uppercased copy of s. The uppercasing algorithm is described in
 // section 3.13 of the Unicode Standard.
 ypAPI ypObject *yp_upper(ypObject *s);
 
-// Returns a new reference to a "casefolded" copy of s, for use in caseless matching.  The
+// Returns a new reference to a "casefolded" copy of s, for use in caseless matching. The
 // casefolding algorithm is described in section 3.13 of the Unicode Standard.
 ypAPI ypObject *yp_casefold(ypObject *s);
 
@@ -1050,8 +1050,8 @@ ypAPI ypObject *yp_swapcase(ypObject *s);
 // lowercased.
 ypAPI ypObject *yp_capitalize(ypObject *s);
 
-// Returns a new reference to s left-justified in a string of length width.  Padding is done using
-// the specified ord_fillchar for yp_ljustC3, or a space for yp_ljustC.  A copy of s is returned if
+// Returns a new reference to s left-justified in a string of length width. Padding is done using
+// the specified ord_fillchar for yp_ljustC3, or a space for yp_ljustC. A copy of s is returned if
 // width is less than or equal to its length.
 ypAPI ypObject *yp_ljustC3(ypObject *s, yp_ssize_t width, yp_int_t ord_fillchar);
 ypAPI ypObject *yp_ljustC(ypObject *s, yp_ssize_t width);
@@ -1065,17 +1065,17 @@ ypAPI ypObject *yp_centerC3(ypObject *s, yp_ssize_t width, yp_int_t ord_fillchar
 ypAPI ypObject *yp_centerC(ypObject *s, yp_ssize_t width);
 
 // Returns a new reference to s where all tab characters are replaced by one or more spaces,
-// depending on the current column and the given tabsize.  Newline and return characters reset the
+// depending on the current column and the given tabsize. Newline and return characters reset the
 // column to zero; all other characters increment the column by one regardless of how the character
-// is represented when printed.  The Python-equivalent "default" for tabsize is 8.
+// is represented when printed. The Python-equivalent "default" for tabsize is 8.
 ypAPI ypObject *yp_expandtabsC(ypObject *s, yp_ssize_t tabsize);
 
 // Returns a new reference to a copy of s with count occurrences of substring oldsub replaced by
-// newsub.  For yp_replace, or if count is -1, all occurrences are replaced.
+// newsub. For yp_replace, or if count is -1, all occurrences are replaced.
 ypAPI ypObject *yp_replaceC4(ypObject *s, ypObject *oldsub, ypObject *newsub, yp_ssize_t count);
 ypAPI ypObject *yp_replace(ypObject *s, ypObject *oldsub, ypObject *newsub);
 
-// Returns a new reference to a copy of s with leading characters removed.  The chars argument is a
+// Returns a new reference to a copy of s with leading characters removed. The chars argument is a
 // string specifying the set of characters to be removed; for yp_lstrip, or if chars is yp_None,
 // this defaults to removing whitespace.
 ypAPI ypObject *yp_lstrip2(ypObject *s, ypObject *chars);
@@ -1090,7 +1090,7 @@ ypAPI ypObject *yp_strip2(ypObject *s, ypObject *chars);
 ypAPI ypObject *yp_strip(ypObject *s);
 
 // Returns a new reference to the concatenation of the strings in iterable, using s as the
-// separator between elements.  Raises yp_TypeError if there are any non-string values.
+// separator between elements. Raises yp_TypeError if there are any non-string values.
 ypAPI ypObject *yp_join(ypObject *s, ypObject *iterable);
 
 // Equivalent to yp_join(s, yp_tupleN(n, ...)).
@@ -1098,8 +1098,8 @@ ypAPI ypObject *yp_joinN(ypObject *s, int n, ...);
 ypAPI ypObject *yp_joinNV(ypObject *s, int n, va_list args);
 
 // Splits s at the first occurrence of sep and returns new references to 3 objects: *part0 is the
-// part before the separator, *part1 the separator itself, and *part2 the part after.  If the
-// separator is not found, *part0 is a copy of s, and *part1 and *part2 are empty strings.  Sets
+// part before the separator, *part1 the separator itself, and *part2 the part after. If the
+// separator is not found, *part0 is a copy of s, and *part1 and *part2 are empty strings. Sets
 // all 3 ypObject**s to the same exception on error.
 ypAPI void yp_partition(
         ypObject *s, ypObject *sep, ypObject **part0, ypObject **part1, ypObject **part2);
@@ -1111,14 +1111,14 @@ ypAPI void yp_rpartition(
 
 // Returns a new reference to a list of words in the string, using sep as the delimiter string.
 // For yp_splitC3, only performs the leftmost splits up to maxsplit; for yp_split2, or if maxsplit
-// is -1, there is no limit on the number of splits made.  If sep is yp_None this behaves as
+// is -1, there is no limit on the number of splits made. If sep is yp_None this behaves as
 // yp_split, otherwise consecutive delimiters are not grouped together and are deemed to delimit
 // empty strings.
 //  Ex: yp_split2("1,,2", ",") returns ["1", "", "2"]
 ypAPI ypObject *yp_splitC3(ypObject *s, ypObject *sep, yp_ssize_t maxsplit);
 ypAPI ypObject *yp_split2(ypObject *s, ypObject *sep);
 
-// Similar to yp_splitC3, except a different splitting algorithm is used.  Runs of consecutive
+// Similar to yp_splitC3, except a different splitting algorithm is used. Runs of consecutive
 // whitespace are regarded as a single separator and the result will contain no empty strings at
 // the start or end if the string has leading or trailing whitespace.
 //  Ex: yp_split(" 1  2   3  ") returns ["1", "2", "3"]
@@ -1128,8 +1128,8 @@ ypAPI ypObject *yp_split(ypObject *s);
 //  Ex: yp_rsplitC3("  1  2   3  ", yp_None, 1) returns ["  1  2", "3"]
 ypAPI ypObject *yp_rsplitC3(ypObject *s, ypObject *sep, yp_ssize_t maxsplit);
 
-// Returns a new reference to a list of lines in the string, breaking at line boundaries.  Python's
-// "universal newlines" approach is used to split lines.  Line breaks are not included in the
+// Returns a new reference to a list of lines in the string, breaking at line boundaries. Python's
+// "universal newlines" approach is used to split lines. Line breaks are not included in the
 // resulting list unless keepends is true.
 ypAPI ypObject *yp_splitlines2(ypObject *s, ypObject *keepends);
 
@@ -1284,8 +1284,8 @@ ypAPI ypObject *const yp_func_sorted;
 // The numeric types include ints and floats (and their mutable counterparts, of course).
 
 // Each of these methods return new reference(s) to the result of the given numeric operation;
-// for example, yp_add returns the result of adding x and y together.  If the given operands do not
-// support the operation, yp_TypeError is returned.  Additional notes:
+// for example, yp_add returns the result of adding x and y together. If the given operands do not
+// support the operation, yp_TypeError is returned. Additional notes:
 //  - yp_divmod returns two objects via *div and *mod; on error, they are both set to an exception
 //  - If z is yp_None, yp_pow3 returns x to the power y, otherwise x to the power y modulo z
 //  - To avoid confusion with the logical operators of the same name, yp_amp implements bitwise
@@ -1312,8 +1312,8 @@ ypAPI ypObject *yp_bar(ypObject *x, ypObject *y);
 ypAPI ypObject *yp_invert(ypObject *x);
 
 // In-place versions of the above; if the object *x can be modified to hold the result, it is,
-// otherwise *x is discarded and replaced with the result.  If *x is immutable on input, an
-// immutable object is returned, otherwise a mutable object is returned.  On error, *x is
+// otherwise *x is discarded and replaced with the result. If *x is immutable on input, an
+// immutable object is returned, otherwise a mutable object is returned. On error, *x is
 // discarded and set to an exception.
 ypAPI void yp_iadd(ypObject **x, ypObject *y);
 ypAPI void yp_isub(ypObject **x, ypObject *y);
@@ -1333,7 +1333,7 @@ ypAPI void yp_ixor(ypObject **x, ypObject *y);
 ypAPI void yp_ibar(ypObject **x, ypObject *y);
 ypAPI void yp_iinvert(ypObject **x);
 
-// Versions of yp_iadd et al that accept a C integer as the second argument.  Remember that *x may
+// Versions of yp_iadd et al that accept a C integer as the second argument. Remember that *x may
 // be discarded and replaced with the result.
 ypAPI void yp_iaddC(ypObject **x, yp_int_t y);
 ypAPI void yp_isubC(ypObject **x, yp_int_t y);
@@ -1349,7 +1349,7 @@ ypAPI void yp_iampC(ypObject **x, yp_int_t y);
 ypAPI void yp_ixorC(ypObject **x, yp_int_t y);
 ypAPI void yp_ibarC(ypObject **x, yp_int_t y);
 
-// Versions of yp_iadd et al that accept a C floating-point as the second argument.  Remember that
+// Versions of yp_iadd et al that accept a C floating-point as the second argument. Remember that
 // *x may be discarded and replaced with the result.
 ypAPI void yp_iaddCF(ypObject **x, yp_float_t y);
 ypAPI void yp_isubCF(ypObject **x, yp_float_t y);
@@ -1359,7 +1359,7 @@ ypAPI void yp_ifloordivCF(ypObject **x, yp_float_t y);
 ypAPI void yp_imodCF(ypObject **x, yp_float_t y);
 ypAPI void yp_ipowCF(ypObject **x, yp_float_t y);
 
-// Library routines for nohtyP integer operations on C types.  Returns zero and sets *exc on error.
+// Library routines for nohtyP integer operations on C types. Returns zero and sets *exc on error.
 // Additional notes:
 //  - yp_truedivL returns a floating-point number
 //  - If z is 0, yp_powL3 returns x to the power y, otherwise x to the power y modulo z
@@ -1384,7 +1384,7 @@ ypAPI yp_int_t   yp_xorL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI yp_int_t   yp_barL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI yp_int_t   yp_invertL(yp_int_t x, ypObject **exc);
 
-// Library routines for nohtyP floating-point operations on C types.  Returns zero and sets *exc
+// Library routines for nohtyP floating-point operations on C types. Returns zero and sets *exc
 // on error.
 ypAPI yp_float_t yp_addLF(yp_float_t x, yp_float_t y, ypObject **exc);
 ypAPI yp_float_t yp_subLF(yp_float_t x, yp_float_t y, ypObject **exc);
@@ -1399,8 +1399,8 @@ ypAPI yp_float_t yp_negLF(yp_float_t x, ypObject **exc);
 ypAPI yp_float_t yp_posLF(yp_float_t x, ypObject **exc);
 ypAPI yp_float_t yp_absLF(yp_float_t x, ypObject **exc);
 
-// Conversion routines from C types or objects to C types.  Returns a reasonable value and sets
-// *exc on error; "reasonable" usually means "truncated".  Converting a float to an int truncates
+// Conversion routines from C types or objects to C types. Returns a reasonable value and sets
+// *exc on error; "reasonable" usually means "truncated". Converting a float to an int truncates
 // toward zero but is not an error.
 ypAPI yp_int_t     yp_asintC(ypObject *x, ypObject **exc);
 ypAPI yp_int8_t    yp_asint8C(ypObject *x, ypObject **exc);
@@ -1430,7 +1430,7 @@ ypAPI ypObject *yp_sumNV(int n, va_list args);
 ypAPI ypObject *yp_sum(ypObject *iterable);
 
 // Return the number of bits necessary to represent an integer in binary, excluding the sign and
-// leading zeroes.  Returns zero and sets *exc on error.
+// leading zeroes. Returns zero and sets *exc on error.
 ypAPI yp_int_t yp_int_bit_lengthC(ypObject *x, ypObject **exc);
 
 // The maximum and minimum integer values, as immortal objects.
@@ -1461,13 +1461,13 @@ ypAPI ypObject *const yp_i_two;
 // Unlike Python, most objects are deep copied in memory, even immutables, as deep copying is one
 // strategy to maintain threadsafety.
 
-// Transmutes *x to its associated immutable type.  If *x is already immutable this is a no-op.
+// Transmutes *x to its associated immutable type. If *x is already immutable this is a no-op.
 ypAPI void yp_freeze(ypObject **x);
 
 // Freezes *x and, recursively, all contained objects.
 ypAPI void yp_deepfreeze(ypObject **x);
 
-// Returns a new reference to a mutable shallow copy of x.  If x has no associated mutable type an
+// Returns a new reference to a mutable shallow copy of x. If x has no associated mutable type an
 // immutable copy is returned.
 ypAPI ypObject *yp_unfrozen_copy(ypObject *x);
 
@@ -1496,11 +1496,11 @@ ypAPI ypObject *yp_copy(ypObject *x);
 ypAPI ypObject *yp_deepcopy(ypObject *x);
 
 // Discards all contained objects in *x, deallocates _some_ memory, and transmutes it to the
-// ypInvalidated type (rendering the object useless).  If *x is immortal or already invalidated
+// ypInvalidated type (rendering the object useless). If *x is immortal or already invalidated
 // this is a no-op; immutable objects _can_ be invalidated.
 ypAPI void yp_invalidate(ypObject **x);
 
-// Invalidates *x and, recursively, all contained objects.  As nohtyP does not currently detect
+// Invalidates *x and, recursively, all contained objects. As nohtyP does not currently detect
 // reference cycles during garbage collection, this is an effective way to break cycles and free
 // memory.
 ypAPI void yp_deepinvalidate(ypObject **x);
@@ -1510,11 +1510,11 @@ ypAPI void yp_deepinvalidate(ypObject **x);
  * Type Operations
  */
 
-// Returns a new reference to the type of object.  If object is an exception, yp_t_exception is
+// Returns a new reference to the type of object. If object is an exception, yp_t_exception is
 // returned; if it is invalidated, yp_t_invalidated is returned.
 ypAPI ypObject *yp_type(ypObject *object);
 
-// The immortal type objects.  Calling a type object (e.g., with yp_callN) typically constructs an
+// The immortal type objects. Calling a type object (e.g., with yp_callN) typically constructs an
 // object of that type.
 ypAPI ypObject *const yp_t_invalidated;
 ypAPI ypObject *const yp_t_exception;
@@ -1592,9 +1592,9 @@ typedef struct _yp_state_decl_t {
  */
 
 // The "mini iterator" API is an alternative to the standard iterator API (yp_iter et al) that can
-// in most cases avoid allocating a separate iterator object.  This makes it the preferred API to
+// in most cases avoid allocating a separate iterator object. This makes it the preferred API to
 // loop over an iterable, although there are restrictions: the mini iterator returned by yp_miniiter
-// is opaque and can only be used with the yp_miniiter_* methods and yp_decref.  So, as an example,
+// is opaque and can only be used with the yp_miniiter_* methods and yp_decref. So, as an example,
 // if you need to store an iterator in a list, stick with yp_iter.
 //
 // The restrictions on how mini iterators are used means you'll typically write the following:
@@ -1609,40 +1609,40 @@ typedef struct _yp_state_decl_t {
 //      yp_decref(mi);
 //
 // All iterables can be used with yp_miniiter, even if they do not specifically support the mini
-// iterator protocol.  Additionally, types that do support the protocol may yet allocate a separate
+// iterator protocol. Additionally, types that do support the protocol may yet allocate a separate
 // object under certain conditions (if a yp_uint64_t is too small to hold the necessary state,
-// perhaps).  It is for this reason that mini iterator objects be treated as opaque: the type of the
-// returned object may not be consistent.  These restrictions on using mini iterators are not
+// perhaps). It is for this reason that mini iterator objects be treated as opaque: the type of the
+// returned object may not be consistent. These restrictions on using mini iterators are not
 // enforced: the behaviour of a mini iterator with any other other function is undefined and may or
 // may not raise an exception.
 
 // Returns a new reference to an opaque mini iterator for object x and initializes *state to the
-// iterator's starting state.  *state is also opaque: you must *not* modify it directly.  It is
+// iterator's starting state. *state is also opaque: you must *not* modify it directly. It is
 // usually unwise to modify an object being iterated over.
 ypAPI ypObject *yp_miniiter(ypObject *x, yp_uint64_t *state);
 
 // Returns a new reference to the next yielded value from the mini iterator, or an exception.
-// state must point to the same data returned by the previous yp_miniiter* call.  When the mini
+// state must point to the same data returned by the previous yp_miniiter* call. When the mini
 // iterator is exhausted yp_StopIteration is returned; on any other error, *mi is discarded and set
 // to an exception, _and_ an exception is returned.
 ypAPI ypObject *yp_miniiter_next(ypObject **mi, yp_uint64_t *state);
 
-// Returns a hint as to how many items are left to be yielded.  See yp_length_hintC for
-// additional information.  state must point to the same data returned by the previous yp_miniiter*
-// call.  Returns zero and sets *exc on error.
+// Returns a hint as to how many items are left to be yielded. See yp_length_hintC for
+// additional information. state must point to the same data returned by the previous yp_miniiter*
+// call. Returns zero and sets *exc on error.
 ypAPI yp_ssize_t yp_miniiter_length_hintC(ypObject *mi, yp_uint64_t *state, ypObject **exc);
 
-// Mini iterator versions of yp_iter_keys and yp_iter_values.  Otherwise behaves as yp_miniiter.
+// Mini iterator versions of yp_iter_keys and yp_iter_values. Otherwise behaves as yp_miniiter.
 ypAPI ypObject *yp_miniiter_keys(ypObject *x, yp_uint64_t *state);
 ypAPI ypObject *yp_miniiter_values(ypObject *x, yp_uint64_t *state);
 
-// A mini iterator version of yp_iter_items.  Otherwise behaves as yp_miniiter.  While
+// A mini iterator version of yp_iter_items. Otherwise behaves as yp_miniiter. While
 // yp_miniiter_next can be used, yp_miniiter_items_next is recommended to avoid allocating a new
 // tuple for each key/value pair.
 ypAPI ypObject *yp_miniiter_items(ypObject *x, yp_uint64_t *state);
 
 // Returns new references to the next yielded key/value pair from the mini iterator, or an
-// exception.  state must point to the same data returned by the previous yp_miniiter* call.  Only
+// exception. state must point to the same data returned by the previous yp_miniiter* call. Only
 // applicable for mini iterators returned by yp_miniiter_items, otherwise yp_TypeError is raised.
 // When the mini iterator is exhausted both *key and *value are set to yp_StopIteration; on any
 // other error, *mi is discarded and set to an exception, _and_ both *key and *value are set to
@@ -1656,12 +1656,12 @@ ypAPI void yp_miniiter_items_next(
  */
 
 // When working with containers, it can be convenient to perform operations using C types rather
-// than dealing with reference counting.  These functions provide shortcuts for common operations
-// when dealing with containers.  Keep in mind, though, that many of these functions create
+// than dealing with reference counting. These functions provide shortcuts for common operations
+// when dealing with containers. Keep in mind, though, that many of these functions create
 // short-lived objects internally, so excessive use may impact execution time.
 
 // For functions that deal with strs, if encoding is missing yp_s_utf_8 (which is compatible
-// with ascii) is assumed, while if errors is missing yp_s_strict is assumed.  yp_*_containsC
+// with ascii) is assumed, while if errors is missing yp_s_strict is assumed. yp_*_containsC
 // returns false and sets *exc on exception.
 
 // Operations on containers that map objects to integers
@@ -1676,7 +1676,7 @@ ypAPI void     yp_o2i_setitemC(ypObject **container, ypObject *key, yp_int_t x);
 ypAPI void yp_o2s_setitemC4(
         ypObject **container, ypObject *key, const yp_uint8_t *x, yp_ssize_t x_len);
 
-// Operations on containers that map integers to objects.  Note that if the container is known
+// Operations on containers that map integers to objects. Note that if the container is known
 // at compile-time to be a sequence, then yp_getindexC et al are better choices.
 ypAPI ypObject *yp_i2o_getitemC(ypObject *container, yp_int_t key);
 ypAPI void      yp_i2o_setitemC(ypObject **container, yp_int_t key, ypObject *x);
@@ -1690,7 +1690,7 @@ ypAPI void     yp_i2i_setitemC(ypObject **container, yp_int_t key, yp_int_t x);
 ypAPI void yp_i2s_setitemC4(
         ypObject **container, yp_int_t key, const yp_uint8_t *x, yp_ssize_t x_len);
 
-// Operations on containers that map strs to objects.  Note that if the value of the str is
+// Operations on containers that map strs to objects. Note that if the value of the str is
 // known at compile-time, as in:
 //      value = yp_s2o_getitemC3(o, "mykey", -1);
 // it is more efficient to use yp_IMMORTAL_STR_LATIN_1 (also compatible with ascii), as in:
@@ -1712,26 +1712,26 @@ ypAPI void yp_s2i_setitemC4(
  */
 
 // Defines an immortal int object at compile-time, which can be accessed by the variable name,
-// which is of type "ypObject * const".  value is a (constant) yp_int_t.  To be used as:
+// which is of type "ypObject * const". value is a (constant) yp_int_t. To be used as:
 //      yp_IMMORTAL_INT(name, value);
 
 // Defines an immortal bytes object at compile-time, which can be accessed by the variable name,
-// which is of type "ypObject * const".  value is a C string literal that can contain null bytes.
+// which is of type "ypObject * const". value is a C string literal that can contain null bytes.
 // The length is calculated while compiling; the hash will be calculated the first time it is
-// accessed.  To be used as:
+// accessed. To be used as:
 //      yp_IMMORTAL_BYTES(name, value);
 
 // Defines an immortal str constant at compile-time, which can be accessed by the variable name,
-// which is of type "ypObject * const".  value is a latin-1 encoded C string literal that can
-// contain null characters.  The length is calculated while compiling; the hash will be calculated
-// the first time it is accessed.  Note that this also accepts an ascii-encoded C string literal,
+// which is of type "ypObject * const". value is a latin-1 encoded C string literal that can
+// contain null characters. The length is calculated while compiling; the hash will be calculated
+// the first time it is accessed. Note that this also accepts an ascii-encoded C string literal,
 // as ascii is a subset of latin-1.
 //      yp_IMMORTAL_STR_LATIN_1(name, value);
 
-// The default immortal "constructor" macros declare variables as "ypObject * const".  This means
-// immortals defined outside of a function will be extern.  It also means you should *not*
+// The default immortal "constructor" macros declare variables as "ypObject * const". This means
+// immortals defined outside of a function will be extern. It also means you should *not*
 // use these macros in a function, as the variable will be "deallocated" when the function returns,
-// and immortals should never be deallocated.  The following macros work as above, except the
+// and immortals should never be deallocated. The following macros work as above, except the
 // variables are declared as "static ypObject * const".
 //      yp_IMMORTAL_INT_static(name, value);
 //      yp_IMMORTAL_BYTES_static(name, value);
@@ -1791,12 +1791,12 @@ ypAPI ypObject *const yp_SystemLimitationError;
 // Raised when an invalidated object is passed to a function; subexception of yp_TypeError.
 ypAPI ypObject *const yp_InvalidatedError;
 
-// Returns true (non-zero) if x is an exception that matches exc, else false.  This takes into
-// account the exception heirarchy, so is the preferred way to test for specific exceptions.  Always
+// Returns true (non-zero) if x is an exception that matches exc, else false. This takes into
+// account the exception heirarchy, so is the preferred way to test for specific exceptions. Always
 // succeeds.
 ypAPI int yp_isexceptionC2(ypObject *x, ypObject *exc);
 
-// A convenience function to compare x against n possible exceptions.  Returns false if n is zero.
+// A convenience function to compare x against n possible exceptions. Returns false if n is zero.
 ypAPI int yp_isexceptionCN(ypObject *x, int n, ...);
 ypAPI int yp_isexceptionCNV(ypObject *x, int n, va_list args);
 
@@ -1829,17 +1829,17 @@ typedef struct _yp_initialize_parameters_t {
     yp_ssize_t sizeof_struct;  // Set to sizeof(yp_initialize_parameters_t)
 
     // yp_malloc, yp_malloc_resize, and yp_free allow you to specify a custom memory allocation API.
-    // It is recommended to set these to NULL to use nohtyP's defaults.  Any functions you supply
+    // It is recommended to set these to NULL to use nohtyP's defaults. Any functions you supply
     // should behave exactly as documented, and you are encouraged to run the full suite of tests
-    // with your API.  (See yp_mem_default_malloc et al in nohtyP.c for examples.)
+    // with your API. (See yp_mem_default_malloc et al in nohtyP.c for examples.)
 
     // Allocates at least size bytes of memory, setting *actual to the actual amount of memory
-    // allocated, and returning the pointer to the buffer.  On error, returns NULL, and *actual is
-    // undefined.  This must succeed when size==0; the behaviour is undefined when size<0.
+    // allocated, and returning the pointer to the buffer. On error, returns NULL, and *actual is
+    // undefined. This must succeed when size==0; the behaviour is undefined when size<0.
     // XXX It's recommended that negative sizes abort in debug builds to catch overflow errors.
     void *(*yp_malloc)(yp_ssize_t *actual, yp_ssize_t size);
 
-    // Resizes the given buffer in-place if possible, otherwise allocates a new buffer.  There are
+    // Resizes the given buffer in-place if possible, otherwise allocates a new buffer. There are
     // three possible scenarios:
     //  - On error, returns NULL, p is not freed, and *actual is undefined
     //  - On successful in-place resize, returns p, and *actual is the amount of memory now
@@ -1847,18 +1847,18 @@ typedef struct _yp_initialize_parameters_t {
     //  - Otherwise, returns a pointer to the new buffer, p is not freed, and *actual is the amount
     //  of memory allocated to the new buffer; nohtyP will then copy the data and call yp_free(p)
     // The resized/new buffer will be at least size bytes; extra is a hint as to how much the
-    // buffer should be over-allocated, which may be ignored.  This must succeed when size==0 or
+    // buffer should be over-allocated, which may be ignored. This must succeed when size==0 or
     // extra==0; the behaviour is undefined when size<0 or extra<0.
     // XXX Unlike realloc, this *never* copies to the new buffer and *never* frees the old buffer.
     // XXX It's recommended that negative sizes abort in debug builds to catch overflow errors.
     void *(*yp_malloc_resize)(yp_ssize_t *actual, void *p, yp_ssize_t size, yp_ssize_t extra);
 
-    // Frees memory returned by yp_malloc and yp_malloc_resize.  May abort on error.
+    // Frees memory returned by yp_malloc and yp_malloc_resize. May abort on error.
     void (*yp_free)(void *p);
 
     // Setting everything_immortal to true forces all allocated objects to be immortal, effectively
-    // disabling yp_incref and yp_decref.  When false, the default and recommended option, objects
-    // are deallocated when their reference count reaches zero.  Setting this option will leak
+    // disabling yp_incref and yp_decref. When false, the default and recommended option, objects
+    // are deallocated when their reference count reaches zero. Setting this option will leak
     // considerable amounts of memory, but if the number of objects allocated by your program is
     // bounded you may notice a small performance improvement.
     // XXX Use this option carefully, and profile to ensure it actually provides a benefit!
@@ -1898,28 +1898,28 @@ ypAPI ypObject *yp_function_stateCX(ypObject *function, void **state, yp_ssize_t
 
 // For sequences that store their elements as an array of bytes (bytes and bytearray), sets *bytes
 // to the beginning of that array, *len to the length of the sequence, and returns the immortal
-// yp_None.  *bytes will point into internal object memory which MUST NOT be modified; furthermore,
-// the sequence itself must not be modified while using the array.  As a special case, if len is
+// yp_None. *bytes will point into internal object memory which MUST NOT be modified; furthermore,
+// the sequence itself must not be modified while using the array. As a special case, if len is
 // NULL, the sequence must not contain null bytes and *bytes will point to a null-terminated array.
 // Sets *bytes to NULL, *len to zero (if len is not NULL), and returns an exception on error.
 ypAPI ypObject *yp_asbytesCX(ypObject *seq, const yp_uint8_t **bytes, yp_ssize_t *len);
 
 // str and chrarray internally store their Unicode characters in particular encodings, usually
-// depending on the contents of the string.  This function sets *encoded to the beginning of that
+// depending on the contents of the string. This function sets *encoded to the beginning of that
 // data, *size to the number of bytes in encoded, and *encoding to the immortal str representing
-// the encoding used (yp_s_latin_1, perhaps).  *encoded will point into internal object memory
+// the encoding used (yp_s_latin_1, perhaps). *encoded will point into internal object memory
 // which MUST NOT be modified; furthermore, the string itself must not be modified while using the
-// array.  As a special case, if size is NULL, the string must not contain null characters and
-// *encoded will point to a null-terminated string.  On error, sets *encoded to NULL, *size to
+// array. As a special case, if size is NULL, the string must not contain null characters and
+// *encoded will point to a null-terminated string. On error, sets *encoded to NULL, *size to
 // zero (if size is not NULL), *encoding to the exception, and returns the exception.
 ypAPI ypObject *yp_asencodedCX(
         ypObject *seq, const yp_uint8_t **encoded, yp_ssize_t *size, ypObject **encoding);
 
 // For sequences that store their elements as an array of pointers to ypObjects (list and tuple),
 // sets *array to the beginning of that array, *len to the length of the sequence, and returns the
-// immortal yp_None.  *array will point into internal object memory, so they are *borrowed*
+// immortal yp_None. *array will point into internal object memory, so they are *borrowed*
 // references and MUST NOT be replaced; furthermore, the sequence itself must not be modified while
-// using the array.  Sets *array to NULL, *len to zero, and returns an exception on error.
+// using the array. Sets *array to NULL, *len to zero, and returns an exception on error.
 ypAPI ypObject *yp_itemarrayCX(ypObject *seq, ypObject *const **array, yp_ssize_t *len);
 
 // Similar to yp_callN, except the callable is at args[0] and the arguments start at args[1]. n is
@@ -1933,13 +1933,13 @@ ypAPI ypObject *yp_call_arrayX(yp_ssize_t n, ypObject **args);
 
 // For tuples, lists, dicts, and frozendicts, this is equivalent to:
 //  yp_asencodedCX(yp_getitem(container, key), encoded, size, encoding)
-// For all other types, this raises yp_TypeError, and sets the outputs accordingly.  *encoded
+// For all other types, this raises yp_TypeError, and sets the outputs accordingly. *encoded
 // will point into internal object memory which MUST NOT be modified; furthermore, the str
 // itself must neither be modified nor removed from the container while using the array.
 ypAPI ypObject *yp_o2s_getitemCX(ypObject *container, ypObject *key, const yp_uint8_t **encoded,
         yp_ssize_t *size, ypObject **encoding);
 
-// Similar to yp_o2s_getitemCX, except key is a yp_int_t.  *encoded will point into internal object
+// Similar to yp_o2s_getitemCX, except key is a yp_int_t. *encoded will point into internal object
 // memory which MUST NOT be modified; furthermore, the str itself must neither be modified nor
 // removed from the container while using the array.
 ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uint8_t **encoded,
@@ -1949,12 +1949,12 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 /*
  * Optional Macros
  *
- * These macros may make working with nohtyP easier, but are not required.  They are best described
+ * These macros may make working with nohtyP easier, but are not required. They are best described
  * by the examples in ypExamples.c, but are documented below.
  */
 
 #ifdef yp_FUTURE
-// yp_IF: A series of macros to emulate an if/elif/else with exception handling.  To be used
+// yp_IF: A series of macros to emulate an if/elif/else with exception handling. To be used
 // strictly as follows (including braces):
 //      yp_IF(condition1) {
 //          // branch1
@@ -1965,20 +1965,20 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 //      } yp_ELSE_EXCEPT_AS(e) {  // optional; can also use yp_ELSE_EXCEPT
 //          // exception-branch
 //      } yp_ENDIF
-// C's return statement works as you'd expect.  yp_ELSE_EXCEPT_AS defines the exception target
+// C's return statement works as you'd expect. yp_ELSE_EXCEPT_AS defines the exception target
 // variable.
 //
 // As in Python, a condition is only evaluated if previous conditions evaluated false and did not
 // raise an exception, the exception-branch is executed if any evaluated condition raises an
-// exception, and the exception target is only available inside exception-branch.  Unlike Python,
-// exceptions in the chosen branch do not trigger the exception-branch.  If a condition creates a
+// exception, and the exception target is only available inside exception-branch. Unlike Python,
+// exceptions in the chosen branch do not trigger the exception-branch. If a condition creates a
 // new reference that must be discarded, use yp_IFd and/or yp_ELIFd ("d" stands for "discard" or
 // "decref"):
 //      yp_IFd(yp_getitem(a, key))
 #endif
 
 #ifdef yp_FUTURE
-// yp_WHILE: A series of macros to emulate a while/else with exception handling.  To be used
+// yp_WHILE: A series of macros to emulate a while/else with exception handling. To be used
 // strictly as follows (including braces):
 //      yp_WHILE(condition) {
 //          // suite
@@ -1987,7 +1987,7 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 //      } yp_WHILE_EXCEPT_AS(e) { // optional; can also use yp_WHILE_EXCEPT
 //          // exception-suite
 //      } yp_ENDWHILE
-// C's break, continue, and return statements work as you'd expect.  yp_WHILE_EXCEPT_AS defines the
+// C's break, continue, and return statements work as you'd expect. yp_WHILE_EXCEPT_AS defines the
 // exception target variable.
 //
 // As in Python, the condition is evaluated multiple times until:
@@ -1995,14 +1995,14 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 //  - a break statement, in which case neither the else- nor exception-suites are executed
 //  - an exception occurs in condition, in which case the exception target (which is only available
 //  inside exception-suite) is set to the exception and the exception-suite is executed
-// Unlike Python, exceptions in the suites do not trigger the exception-suite.  If condition
+// Unlike Python, exceptions in the suites do not trigger the exception-suite. If condition
 // creates a new reference that must be discarded, use yp_WHILEd ("d" stands for "discard" or
 // "decref"):
 //      yp_WHILEd(yp_getindexC(a, -1))
 #endif
 
 #ifdef yp_FUTURE
-// yp_FOR: A series of macros to emulate a for/else with exception handling.  To be used strictly
+// yp_FOR: A series of macros to emulate a for/else with exception handling. To be used strictly
 // as follows (including braces):
 //      ypObject *x = yp_NameError; // initialize to any new or immortal reference
 //      yp_FOR(x, expression) {
@@ -2013,10 +2013,10 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 //          // exception-suite
 //      } yp_ENDFOR
 // C's break and continue statements work as you'd expect; however, use yp_FOR_return instead of
-// return to avoid leaking a reference.  yp_FOR_EXCEPT_AS defines the exception target variable.
+// return to avoid leaking a reference. yp_FOR_EXCEPT_AS defines the exception target variable.
 //
 // As in Python, the expression is evaluated once to create an iterator, then the suite is executed
-// once for each successfully-yielded value, which is assigned to the target variable.  This
+// once for each successfully-yielded value, which is assigned to the target variable. This
 // occurs until:
 //  - the iterator raises yp_StopIteration, in which case else-suite is executed (but *not* the
 //  exception-suite)
@@ -2025,12 +2025,12 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 //  is only available inside exception-suite) is set to the exception and the exception-suite is
 //  executed
 // Unlike Python, there can only be one target (no automatic tuple unpacking), and exceptions in
-// the suites do not trigger the exception-suite.  If expression creates a new reference that must
+// the suites do not trigger the exception-suite. If expression creates a new reference that must
 // be discarded, use yp_FORd ("d" stands for "discard" or "decref"):
 //      yp_FORd(x, yp_tupleN(3, a, b, c))
 //
 // Before a new reference is assigned to the target variable, the previous reference in the target
-// is automatically discarded.  As such:
+// is automatically discarded. As such:
 //  - if the iterator yields no values, the target's value does not change
 //  - when the loop completes, the target will retain a reference to the last successfully-yielded
 //  value; this includes the else- and exception-suites
@@ -2044,7 +2044,7 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 
 #ifdef yp_FUTURE
 // yp: A set of macros to make nohtyP function calls look more like Python operators and method
-// calls.  Best explained with examples:
+// calls. Best explained with examples:
 //  a.append(b)           --> yp(a,append, b)               --> yp_append(a, b)
 //  a + b                 --> yp(a, add, b)                 --> yp_add(a, b)
 // For methods that take no arguments, use yp1 (the '1' counts the object a, but not the method):

--- a/nohtyP.h
+++ b/nohtyP.h
@@ -244,7 +244,8 @@ ypAPI ypObject *yp_rangeC(yp_int_t stop);
 // Returns a new reference to a bytes/bytearray, copying the first len bytes from source. If
 // source is NULL it is considered as having all null bytes; if len is negative source is
 // considered null terminated (and, therefore, will not contain the null byte).
-//  Ex: pre-allocate a bytearray of length 50: yp_bytearrayC(NULL, 50)
+//
+// Ex: pre-allocate a bytearray of length 50: yp_bytearrayC(NULL, 50)
 ypAPI ypObject *yp_bytesC(const yp_uint8_t *source, yp_ssize_t len);
 ypAPI ypObject *yp_bytearrayC(const yp_uint8_t *source, yp_ssize_t len);
 
@@ -254,9 +255,11 @@ ypAPI ypObject *yp_bytes3(ypObject *source, ypObject *encoding, ypObject *errors
 ypAPI ypObject *yp_bytearray3(ypObject *source, ypObject *encoding, ypObject *errors);
 
 // Returns a new reference to a bytes/bytearray object, depending on the type of source:
-//  - integer: the array will have that size and be initialized with null bytes
-//  - iterable: it must be an iterable of integers in range(256) used to initialize the array (this
-//  includes bytes and bytearray objects)
+//
+// - integer: the array will have that size and be initialized with null bytes
+// - iterable: it must be an iterable of integers in range(256) used to initialize the array (this
+//   includes bytes and bytearray objects)
+//
 // Raises yp_TypeError if source is a str/chrarray; instead, use yp_bytes3/yp_bytearray3.
 ypAPI ypObject *yp_bytes(ypObject *source);
 ypAPI ypObject *yp_bytearray(ypObject *source);
@@ -264,10 +267,11 @@ ypAPI ypObject *yp_bytearray(ypObject *source);
 // Returns a new reference to an empty bytearray. (An empty bytes is exported as yp_bytes_empty.)
 ypAPI ypObject *yp_bytearray0(void);
 
-// Returns a new reference to a str/chrarray decoded from the given bytes. source and len are as
-// in yp_bytesC. The Python-equivalent default for encoding is yp_s_utf_8 (compatible with an
+// Returns a new reference to a str/chrarray decoded from the given bytes. source and len are as in
+// yp_bytesC. The Python-equivalent default for encoding is yp_s_utf_8 (compatible with an
 // ascii-encoded source), while for errors it is yp_s_strict. Equivalent to:
-//  yp_str3(yp_bytesC(source, len), encoding, errors)
+//
+//      yp_str3(yp_bytesC(source, len), encoding, errors)
 ypAPI ypObject *yp_str_frombytesC4(
         const yp_uint8_t *source, yp_ssize_t len, ypObject *encoding, ypObject *errors);
 ypAPI ypObject *yp_chrarray_frombytesC4(
@@ -306,8 +310,10 @@ ypAPI ypObject *yp_listNV(int n, va_list args);
 // Returns a new reference to a tuple/list made from factor shallow-copies of yp_tupleN(n, ...)
 // concatenated; the length will be factor*n. Equivalent to "factor * (obj0, obj1, ...)" in
 // Python.
-//  Ex: pre-allocate a list of length 99: yp_list_repeatCN(99, 1, yp_None)
-//  Ex: an 8-tuple containing alternating bools: yp_tuple_repeatCN(4, 2, yp_False, yp_True)
+//
+// Ex: pre-allocate a list of length 99: yp_list_repeatCN(99, 1, yp_None)
+//
+// Ex: an 8-tuple containing alternating bools: yp_tuple_repeatCN(4, 2, yp_False, yp_True)
 ypAPI ypObject *yp_tuple_repeatCN(yp_ssize_t factor, int n, ...);
 ypAPI ypObject *yp_tuple_repeatCNV(yp_ssize_t factor, int n, va_list args);
 ypAPI ypObject *yp_list_repeatCN(yp_ssize_t factor, int n, ...);
@@ -340,7 +346,8 @@ ypAPI ypObject *yp_set(ypObject *iterable);
 // Returns a new reference to a frozendict/dict containing the given n key/value pairs (for a total
 // of 2*n objects); the length will be n, unless there are duplicate keys, in which case the last
 // value will be retained.
-//  Ex: yp_dictK(3, key0, value0, key1, value1, key2, value2)
+//
+// Ex: yp_dictK(3, key0, value0, key1, value1, key2, value2)
 ypAPI ypObject *yp_frozendictK(int n, ...);
 ypAPI ypObject *yp_frozendictKV(int n, va_list args);
 ypAPI ypObject *yp_dictK(int n, ...);
@@ -349,7 +356,8 @@ ypAPI ypObject *yp_dictKV(int n, va_list args);
 // Returns a new reference to a frozendict/dict containing the given n keys all set to value; the
 // length will be n, unless there are duplicate keys. The Python-equivalent default of value is
 // yp_None. Note that, unlike Python, value is the _first_ argument.
-//  Ex: pre-allocate a dict with 3 keys: yp_dict_fromkeysN(yp_None, 3, key0, key1, key2)
+//
+// Ex: pre-allocate a dict with 3 keys: yp_dict_fromkeysN(yp_None, 3, key0, key1, key2)
 ypAPI ypObject *yp_frozendict_fromkeysN(ypObject *value, int n, ...);
 ypAPI ypObject *yp_frozendict_fromkeysNV(ypObject *value, int n, va_list args);
 ypAPI ypObject *yp_dict_fromkeysN(ypObject *value, int n, ...);
@@ -622,7 +630,7 @@ ypAPI ypObject *yp_getindexC(ypObject *sequence, yp_ssize_t i);
 // "defaults" for i and j are yp_SLICE_DEFAULT, while for k it is 1.
 ypAPI ypObject *yp_getsliceC4(ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k);
 
-// Equivalent to yp_getindexC(sequence, yp_asssizeC(key, &exc)).
+// Equivalent to yp_getindexC(sequence, yp_asssizeC(key, exc)).
 ypAPI ypObject *yp_getitem(ypObject *sequence, ypObject *key);
 
 // Returns the lowest index in sequence where x is found, such that x is contained in the slice
@@ -675,7 +683,8 @@ ypAPI void yp_delindexC(ypObject *sequence, yp_ssize_t i, ypObject **exc);
 // Removes the elements of the slice from sequence, from i to j with step k. The Python-
 // equivalent "defaults" for i and j are yp_SLICE_DEFAULT, while for k it is 1. On error,
 // *exc is set to an exception.
-ypAPI void yp_delsliceC4(ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject **exc);
+ypAPI void yp_delsliceC4(
+        ypObject *sequence, yp_ssize_t i, yp_ssize_t j, yp_ssize_t k, ypObject **exc);
 
 // Equivalent to yp_delindexC(sequence, yp_asssizeC(key, exc), exc).
 ypAPI void yp_delitem(ypObject *sequence, ypObject *key, ypObject **exc);
@@ -725,25 +734,29 @@ ypAPI void yp_sort(ypObject *sequence, ypObject **exc);
 
 // When given to a slice-like start/stop C argument, signals that the default "end" value be
 // substituted for the argument. Which end depends on the sign of step:
-//  - positive step: 0 substituted for start, len(s) substituted for stop
-//  - negative step: len(s)-1 substituted for start, -1 substituted for stop
+//
+// - positive step: 0 substituted for start, len(s) substituted for stop
+// - negative step: len(s)-1 substituted for start, -1 substituted for stop
+//
 //  Ex: The nohtyP equivalent of "[::a]" is "yp_SLICE_DEFAULT, yp_SLICE_DEFAULT, a"
 #define yp_SLICE_DEFAULT yp_SSIZE_T_MIN
 
 // When given to a slice-like start/stop C argument, signals that len(s) should be substituted for
 // the argument. In other words, it signals that the slice should start/stop at the end of the
 // sequence.
+//
 //  Ex: The nohtyP equivalent of "[:]" is "0, yp_SLICE_USELEN, 1"
 #define yp_SLICE_USELEN yp_SSIZE_T_MAX
 
 // When an index in a slice is outside of range(-len(s),len(s)), it gets clamped to the bounds of
 // the sequence. Specifically:
-//  - if i>=len(s) and k>0, or i<-len(s) and k<0, the slice is empty, regardless of j
-//  - if i>=len(s) and k<0, the (reversed) slice starts with the last element
-//  - if i<-len(s) and k>0, the slice starts with the first element
-//  - if j>=len(s) and k<0, or j<-len(s) and k>0, the slice is empty, regardless of i
-//  - if j>=len(s) and k>0, the slice ends after the last element
-//  - if j<-len(s) and k<0, the (reversed) slice ends after the first element
+//
+// - if i>=len(s) and k>0, or i<-len(s) and k<0, the slice is empty, regardless of j
+// - if i>=len(s) and k<0, the (reversed) slice starts with the last element
+// - if i<-len(s) and k>0, the slice starts with the first element
+// - if j>=len(s) and k<0, or j<-len(s) and k>0, the slice is empty, regardless of i
+// - if j>=len(s) and k>0, the slice ends after the last element
+// - if j<-len(s) and k<0, the (reversed) slice ends after the first element
 
 // Immortal empty tuple and range objects.
 ypAPI ypObject *const yp_tuple_empty;
@@ -1091,18 +1104,21 @@ ypAPI void yp_rpartition(
 // is -1, there is no limit on the number of splits made. If sep is yp_None this behaves as
 // yp_split, otherwise consecutive delimiters are not grouped together and are deemed to delimit
 // empty strings.
-//  Ex: yp_split2("1,,2", ",") returns ["1", "", "2"]
+//
+// Ex: yp_split2("1,,2", ",") returns ["1", "", "2"]
 ypAPI ypObject *yp_splitC3(ypObject *s, ypObject *sep, yp_ssize_t maxsplit);
 ypAPI ypObject *yp_split2(ypObject *s, ypObject *sep);
 
 // Similar to yp_splitC3, except a different splitting algorithm is used. Runs of consecutive
 // whitespace are regarded as a single separator and the result will contain no empty strings at
 // the start or end if the string has leading or trailing whitespace.
-//  Ex: yp_split(" 1  2   3  ") returns ["1", "2", "3"]
+//
+// Ex: yp_split(" 1  2   3  ") returns ["1", "2", "3"]
 ypAPI ypObject *yp_split(ypObject *s);
 
 // Similar to yp_splitC3, except only performs the rightmost splits up to maxsplit.
-//  Ex: yp_rsplitC3("  1  2   3  ", yp_None, 1) returns ["  1  2", "3"]
+//
+// Ex: yp_rsplitC3("  1  2   3  ", yp_None, 1) returns ["  1  2", "3"]
 ypAPI ypObject *yp_rsplitC3(ypObject *s, ypObject *sep, yp_ssize_t maxsplit);
 
 // Returns a new reference to a list of lines in the string, breaking at line boundaries. Python's
@@ -1260,15 +1276,16 @@ ypAPI ypObject *const yp_func_sorted;
 
 // The numeric types include ints and floats (and their mutable counterparts, of course).
 
-// Each of these methods return new reference(s) to the result of the given numeric operation;
-// for example, yp_add returns the result of adding x and y together. If the given operands do not
+// Each of these methods return new reference(s) to the result of the given numeric operation; for
+// example, yp_add returns the result of adding x and y together. If the given operands do not
 // support the operation, yp_TypeError is returned. Additional notes:
-//  - yp_divmod returns two objects via *div and *mod; on error, they are both set to an exception
-//  - If z is yp_None, yp_pow3 returns x to the power y, otherwise x to the power y modulo z
-//  - To avoid confusion with the logical operators of the same name, yp_amp implements bitwise
-//  and, while yp_bar implements bitwise or
-//  - Bitwise operations (lshift/rshift/amp/xor/bar/invert) are only applicable to integers
-//  - Unlike Python, non-numeric types do not (currently) overload these operators
+//
+// - yp_divmod returns two objects via *div and *mod; on error, they are both set to an exception
+// - If z is yp_None, yp_pow3 returns x to the power y, otherwise x to the power y modulo z
+// - To avoid confusion with the logical operators of the same name, yp_amp implements bitwise and,
+//   while yp_bar implements bitwise or
+// - Bitwise operations (lshift/rshift/amp/xor/bar/invert) are only applicable to integers
+// - Unlike Python, non-numeric types do not (currently) overload these operators
 ypAPI ypObject *yp_add(ypObject *x, ypObject *y);
 ypAPI ypObject *yp_sub(ypObject *x, ypObject *y);
 ypAPI ypObject *yp_mul(ypObject *x, ypObject *y);
@@ -1345,10 +1362,11 @@ ypAPI void yp_ipowCF(ypObject **x, yp_float_t y);
 
 // Library routines for nohtyP integer operations on C types. Returns zero and sets *exc on error.
 // Additional notes:
-//  - yp_truedivL returns a floating-point number
-//  - If z is 0, yp_powL3 returns x to the power y, otherwise x to the power y modulo z
-//  - If y is negative, yp_powL and yp_powL3 raise yp_ValueError, as the result should be a
-//  floating-point number; use yp_powLF for negative exponents instead
+//
+// - yp_truedivL returns a floating-point number
+// - If z is 0, yp_powL3 returns x to the power y, otherwise x to the power y modulo z
+// - If y is negative, yp_powL and yp_powL3 raise yp_ValueError, as the result should be a
+//   floating-point number; use yp_powLF for negative exponents instead
 ypAPI yp_int_t   yp_addL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI yp_int_t   yp_subL(yp_int_t x, yp_int_t y, ypObject **exc);
 ypAPI yp_int_t   yp_mulL(yp_int_t x, yp_int_t y, ypObject **exc);
@@ -1583,6 +1601,7 @@ typedef struct _yp_state_decl_t {
 // if you need to store an iterator in a list, stick with yp_iter.
 //
 // The restrictions on how mini iterators are used means you'll typically write the following:
+//
 //      yp_uint64_t mi_state;
 //      ypObject *mi = yp_miniiter(list, &mi_state);
 //      while(1) {
@@ -1647,15 +1666,14 @@ ypAPI void yp_miniiter_items_next(
 // with ascii) is assumed, while if errors is missing yp_s_strict is assumed. yp_*_containsC
 // returns false and sets *exc on exception.
 
-// Operations on containers that map objects to integers
+// Operations on containers that map objects to integers.
 ypAPI int      yp_o2i_containsC(ypObject *container, yp_int_t x, ypObject **exc);
 ypAPI void     yp_o2i_pushC(ypObject *container, yp_int_t x, ypObject **exc);
 ypAPI yp_int_t yp_o2i_popC(ypObject *container, ypObject **exc);
 ypAPI yp_int_t yp_o2i_getitemC(ypObject *container, ypObject *key, ypObject **exc);
 ypAPI void     yp_o2i_setitemC(ypObject *container, ypObject *key, yp_int_t x, ypObject **exc);
 
-// Operations on containers that map objects to strs
-// yp_o2s_getitemCX is documented below, as it must be used carefully.
+// Operations on containers that map objects to strs. yp_o2s_getitemCX is documented below.
 ypAPI void yp_o2s_setitemC4(
         ypObject **container, ypObject *key, const yp_uint8_t *x, yp_ssize_t x_len);
 
@@ -1664,26 +1682,28 @@ ypAPI void yp_o2s_setitemC4(
 ypAPI ypObject *yp_i2o_getitemC(ypObject *container, yp_int_t key);
 ypAPI void      yp_i2o_setitemC(ypObject *container, yp_int_t key, ypObject *x, ypObject **exc);
 
-// Operations on containers that map integers to integers
+// Operations on containers that map integers to integers.
 ypAPI yp_int_t yp_i2i_getitemC(ypObject *container, yp_int_t key, ypObject **exc);
 ypAPI void     yp_i2i_setitemC(ypObject *container, yp_int_t key, yp_int_t x, ypObject **exc);
 
-// Operations on containers that map integers to strs
-// yp_i2s_getitemCX is documented below, as it must be used carefully.
+// Operations on containers that map integers to strs. yp_i2s_getitemCX is documented below.
 ypAPI void yp_i2s_setitemC4(
         ypObject **container, yp_int_t key, const yp_uint8_t *x, yp_ssize_t x_len);
 
 // Operations on containers that map strs to objects. Note that if the value of the str is
 // known at compile-time, as in:
+//
 //      value = yp_s2o_getitemC3(o, "mykey", -1);
+//
 // it is more efficient to use yp_IMMORTAL_STR_LATIN_1 (also compatible with ascii), as in:
+//
 //      yp_IMMORTAL_STR_LATIN_1(s_mykey, "mykey");
 //      value = yp_getitem(o, s_mykey);
 ypAPI ypObject *yp_s2o_getitemC3(ypObject *container, const yp_uint8_t *key, yp_ssize_t key_len);
 ypAPI void      yp_s2o_setitemC4(
              ypObject **container, const yp_uint8_t *key, yp_ssize_t key_len, ypObject *x);
 
-// Operations on containers that map strs to integers
+// Operations on containers that map strs to integers.
 ypAPI yp_int_t yp_s2i_getitemC3(
         ypObject *container, const yp_uint8_t *key, yp_ssize_t key_len, ypObject **exc);
 ypAPI void yp_s2i_setitemC4(
@@ -1696,12 +1716,14 @@ ypAPI void yp_s2i_setitemC4(
 
 // Defines an immortal int object at compile-time, which can be accessed by the variable name,
 // which is of type "ypObject * const". value is a (constant) yp_int_t. To be used as:
+//
 //      yp_IMMORTAL_INT(name, value);
 
 // Defines an immortal bytes object at compile-time, which can be accessed by the variable name,
 // which is of type "ypObject * const". value is a C string literal that can contain null bytes.
 // The length is calculated while compiling; the hash will be calculated the first time it is
 // accessed. To be used as:
+//
 //      yp_IMMORTAL_BYTES(name, value);
 
 // Defines an immortal str constant at compile-time, which can be accessed by the variable name,
@@ -1709,6 +1731,7 @@ ypAPI void yp_s2i_setitemC4(
 // contain null characters. The length is calculated while compiling; the hash will be calculated
 // the first time it is accessed. Note that this also accepts an ascii-encoded C string literal,
 // as ascii is a subset of latin-1.
+//
 //      yp_IMMORTAL_STR_LATIN_1(name, value);
 
 // The default immortal "constructor" macros declare variables as "ypObject * const". This means
@@ -1716,6 +1739,7 @@ ypAPI void yp_s2i_setitemC4(
 // use these macros in a function, as the variable will be "deallocated" when the function returns,
 // and immortals should never be deallocated. The following macros work as above, except the
 // variables are declared as "static ypObject * const".
+//
 //      yp_IMMORTAL_INT_static(name, value);
 //      yp_IMMORTAL_BYTES_static(name, value);
 //      yp_IMMORTAL_STR_LATIN_1_static(name, value);
@@ -1824,14 +1848,16 @@ typedef struct _yp_initialize_parameters_t {
 
     // Resizes the given buffer in-place if possible, otherwise allocates a new buffer. There are
     // three possible scenarios:
-    //  - On error, returns NULL, p is not freed, and *actual is undefined
-    //  - On successful in-place resize, returns p, and *actual is the amount of memory now
-    //  allocated by p
-    //  - Otherwise, returns a pointer to the new buffer, p is not freed, and *actual is the amount
-    //  of memory allocated to the new buffer; nohtyP will then copy the data and call yp_free(p)
-    // The resized/new buffer will be at least size bytes; extra is a hint as to how much the
-    // buffer should be over-allocated, which may be ignored. This must succeed when size==0 or
-    // extra==0; the behaviour is undefined when size<0 or extra<0.
+    //
+    // - On error, returns NULL, p is not freed, and *actual is undefined
+    // - On successful in-place resize, returns p, and *actual is the amount of memory now allocated
+    //   by p
+    // - Otherwise, returns a pointer to the new buffer, p is not freed, and *actual is the amount
+    //   of memory allocated to the new buffer; nohtyP will then copy the data and call yp_free(p)
+    //
+    // The resized/new buffer will be at least size bytes; extra is a hint as to how much the buffer
+    // should be over-allocated, which may be ignored. This must succeed when size==0 or extra==0;
+    // the behaviour is undefined when size<0 or extra<0.
     // XXX Unlike realloc, this *never* copies to the new buffer and *never* frees the old buffer.
     // XXX It's recommended that negative sizes abort in debug builds to catch overflow errors.
     void *(*yp_malloc_resize)(yp_ssize_t *actual, void *p, yp_ssize_t size, yp_ssize_t extra);
@@ -1915,10 +1941,12 @@ ypAPI ypObject *yp_itemarrayCX(ypObject *seq, ypObject *const **array, yp_ssize_
 ypAPI ypObject *yp_call_arrayX(yp_ssize_t n, ypObject **args);
 
 // For tuples, lists, dicts, and frozendicts, this is equivalent to:
-//  yp_asencodedCX(yp_getitem(container, key), encoded, size, encoding)
-// For all other types, this raises yp_TypeError, and sets the outputs accordingly. *encoded
-// will point into internal object memory which MUST NOT be modified; furthermore, the str
-// itself must neither be modified nor removed from the container while using the array.
+//
+//      yp_asencodedCX(yp_getitem(container, key), encoded, size, encoding)
+//
+// For all other types, this raises yp_TypeError, and sets the outputs accordingly. *encoded will
+// point into internal object memory which MUST NOT be modified; furthermore, the str itself must
+// neither be modified nor removed from the container while using the array.
 ypAPI ypObject *yp_o2s_getitemCX(ypObject *container, ypObject *key, const yp_uint8_t **encoded,
         yp_ssize_t *size, ypObject **encoding);
 
@@ -1939,6 +1967,7 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 #ifdef yp_FUTURE
 // yp_IF: A series of macros to emulate an if/elif/else with exception handling. To be used
 // strictly as follows (including braces):
+//
 //      yp_IF(condition1) {
 //          // branch1
 //      } yp_ELIF(condition2) {   // optional; multiple yp_ELIFs allowed
@@ -1948,6 +1977,7 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 //      } yp_ELSE_EXCEPT_AS(e) {  // optional; can also use yp_ELSE_EXCEPT
 //          // exception-branch
 //      } yp_ENDIF
+//
 // C's return statement works as you'd expect. yp_ELSE_EXCEPT_AS defines the exception target
 // variable.
 //
@@ -1957,12 +1987,14 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 // exceptions in the chosen branch do not trigger the exception-branch. If a condition creates a
 // new reference that must be discarded, use yp_IFd and/or yp_ELIFd ("d" stands for "discard" or
 // "decref"):
+//
 //      yp_IFd(yp_getitem(a, key))
 #endif
 
 #ifdef yp_FUTURE
-// yp_WHILE: A series of macros to emulate a while/else with exception handling. To be used
-// strictly as follows (including braces):
+// yp_WHILE: A series of macros to emulate a while/else with exception handling. To be used strictly
+// as follows (including braces):
+//
 //      yp_WHILE(condition) {
 //          // suite
 //      } yp_WHILE_ELSE {         // optional
@@ -1970,23 +2002,27 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 //      } yp_WHILE_EXCEPT_AS(e) { // optional; can also use yp_WHILE_EXCEPT
 //          // exception-suite
 //      } yp_ENDWHILE
+//
 // C's break, continue, and return statements work as you'd expect. yp_WHILE_EXCEPT_AS defines the
 // exception target variable.
 //
 // As in Python, the condition is evaluated multiple times until:
-//  - it evaluates to false, in which case the else-suite is executed
-//  - a break statement, in which case neither the else- nor exception-suites are executed
-//  - an exception occurs in condition, in which case the exception target (which is only available
-//  inside exception-suite) is set to the exception and the exception-suite is executed
-// Unlike Python, exceptions in the suites do not trigger the exception-suite. If condition
-// creates a new reference that must be discarded, use yp_WHILEd ("d" stands for "discard" or
-// "decref"):
+//
+// - it evaluates to false, in which case the else-suite is executed
+// - a break statement, in which case neither the else- nor exception-suites are executed
+// - an exception occurs in condition, in which case the exception target (which is only available
+//   inside exception-suite) is set to the exception and the exception-suite is executed
+//
+// Unlike Python, exceptions in the suites do not trigger the exception-suite. If condition creates
+// a new reference that must be discarded, use yp_WHILEd ("d" stands for "discard" or "decref"):
+//
 //      yp_WHILEd(yp_getindexC(a, -1))
 #endif
 
 #ifdef yp_FUTURE
-// yp_FOR: A series of macros to emulate a for/else with exception handling. To be used strictly
-// as follows (including braces):
+// yp_FOR: A series of macros to emulate a for/else with exception handling. To be used strictly as
+// follows (including braces):
+//
 //      ypObject *x = yp_NameError; // initialize to any new or immortal reference
 //      yp_FOR(x, expression) {
 //          // suite
@@ -1995,49 +2031,61 @@ ypAPI ypObject *yp_i2s_getitemCX(ypObject *container, yp_int_t key, const yp_uin
 //      } yp_FOR_EXCEPT_AS(e) {     // optional; can also use yp_FOR_EXCEPT
 //          // exception-suite
 //      } yp_ENDFOR
+//
 // C's break and continue statements work as you'd expect; however, use yp_FOR_return instead of
 // return to avoid leaking a reference. yp_FOR_EXCEPT_AS defines the exception target variable.
 //
 // As in Python, the expression is evaluated once to create an iterator, then the suite is executed
-// once for each successfully-yielded value, which is assigned to the target variable. This
-// occurs until:
-//  - the iterator raises yp_StopIteration, in which case else-suite is executed (but *not* the
-//  exception-suite)
-//  - a break statement, in which case neither the else- nor exception-suites are executed
-//  - an exception occurs in expression or the iterator, in which case the exception target (which
-//  is only available inside exception-suite) is set to the exception and the exception-suite is
-//  executed
-// Unlike Python, there can only be one target (no automatic tuple unpacking), and exceptions in
-// the suites do not trigger the exception-suite. If expression creates a new reference that must
-// be discarded, use yp_FORd ("d" stands for "discard" or "decref"):
+// once for each successfully-yielded value, which is assigned to the target variable. This occurs
+// until:
+//
+// - the iterator raises yp_StopIteration (FIXME generator exit? others?), in which case else-suite
+//   is executed (but *not* the exception-suite)
+// - a break statement, in which case neither the else- nor exception-suites are executed
+// - an exception occurs in expression or the iterator, in which case the exception target (which is
+//   only available inside exception-suite) is set to the exception and the exception-suite is
+//   executed
+//
+// Unlike Python, there can only be one target (no automatic tuple unpacking), and exceptions in the
+// suites do not trigger the exception-suite. If expression creates a new reference that must be
+// discarded, use yp_FORd ("d" stands for "discard" or "decref"):
+//
 //      yp_FORd(x, yp_tupleN(3, a, b, c))
 //
 // Before a new reference is assigned to the target variable, the previous reference in the target
 // is automatically discarded. As such:
-//  - if the iterator yields no values, the target's value does not change
-//  - when the loop completes, the target will retain a reference to the last successfully-yielded
-//  value; this includes the else- and exception-suites
-//  - the target *must* have a value before the loop; initializing to yp_NameError mimics Python's
-//  behaviour when the iterator yields no values
-//  - if you assign a new value to the target, remember to discard the previous reference yourself;
-//  also, this new value will be discarded on subsequently-yielded values
-//  - if you want to retain a reference to a yielded value before moving to the next one, create
-//  a new reference (via yp_incref, perhaps)
+//
+// - if the iterator yields no values, the target's value does not change
+// - when the loop completes, the target will retain a reference to the last successfully-yielded
+//   value; this includes the else- and exception-suites
+// - the target *must* have a value before the loop; initializing to yp_NameError mimics Python's
+//   behaviour when the iterator yields no values
+// - if you assign a new value to the target, remember to discard the previous reference yourself;
+//   also, this new value will be discarded on subsequently-yielded values
+// - if you want to retain a reference to a yielded value before moving to the next one, create a
+//   new reference (via yp_incref, perhaps)
 #endif
 
 #ifdef yp_FUTURE
 // yp: A set of macros to make nohtyP function calls look more like Python operators and method
 // calls. Best explained with examples:
-//  a.append(b)           --> yp(a,append, b)               --> yp_append(a, b)
-//  a + b                 --> yp(a, add, b)                 --> yp_add(a, b)
+//
+//      a.append(b) --> yp(a,append, b) --> yp_append(a, b)
+//      a + b       --> yp(a, add, b)   --> yp_add(a, b)
+//
 // For methods that take no arguments, use yp1 (the '1' counts the object a, but not the method):
-//  a.isspace()           --> yp1(a,isspace)                --> yp_isspace(a)
+//
+//      a.isspace() --> yp1(a,isspace) --> yp_isspace(a)
+//
 // If variadic macros are supported by your compiler, yp can take multiple arguments:
-//  a.setdefault(b, c)    --> yp(&a,setdefault, b, c)       --> yp_setdefault(&a, b, c)
-//  a.startswith(b, 2, 7) --> yp(a,startswith4, b, 2, 7)    --> yp_startswith4(a, b, 2, 7)
+//
+//      a.setdefault(b, c)    --> yp(a,setdefault, b, c)     --> yp_setdefault(a, b, c)
+//      a.startswith(b, 2, 7) --> yp(a,startswith4, b, 2, 7) --> yp_startswith4(a, b, 2, 7)
+//
 // If variadic macros are not supported, use yp3, yp4, etc (and define yp_NO_VARIADIC_MACROS):
-//  a.setdefault(b, c)    --> yp3(&a,setdefault, b, c)      --> yp_setdefault(&a, b, c)
-//  a.startswith(b, 2, 7) --> yp4(a,startswith4, b, 2, 7)   --> yp_startswith4(a, b, 2, 7)
+//
+//      a.setdefault(b, c)    --> yp3(a,setdefault, b, c)     --> yp_setdefault(a, b, c)
+//      a.startswith(b, 2, 7) --> yp4(a,startswith4, b, 2, 7) --> yp_startswith4(a, b, 2, 7)
 #endif
 
 
@@ -2079,9 +2127,11 @@ struct _ypIntObject {
     _ypObject_HEAD;
     // TODO If sizeof(yp_int_t)==sizeof(yp_hash_t), we _could_ use ob_hash instead of value,
     // except:
-    //  - ob_hash is currently only supposed to be for immutable values
-    //  - Value -1 gets mapped to hash -2, which if cached would *change the value* of "-1"
-    //  - We could _not_ make this optimization for floats...
+    //
+    // - ob_hash is currently only supposed to be for immutable values
+    // - Value -1 gets mapped to hash -2, which if cached would *change the value* of "-1"
+    // - We could _not_ make this optimization for floats...
+    //
     // So, this may not be a great way to reduce the size of these simpler types.
     yp_int_t value;
 };


### PR DESCRIPTION
One of the goals for nohtyP was to implement a way to have exceptions in C that didn't require thread local storage or checking a return value after every call. An early idea was to make mutating functions accept a `ypObject **` to the object, which would be discarded and replaced with an exception on error. While this was a neat idea, C provides no protections against using a borrowed object for this argument, meaning it would be quite easy to accidentally discard a borrowed reference on error.

This PR removes this "discard object on error" pattern and replaces it with the existing `ypObject **exc` pattern used by functions that return a C value.